### PR TITLE
Introduce reusable GitHub Actions for tagging and releases and refactor CD workflow

### DIFF
--- a/.github/workflows/CD-common-github-release.yml
+++ b/.github/workflows/CD-common-github-release.yml
@@ -1,0 +1,27 @@
+name: CD-common-github-release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      prerelease:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: v${{ inputs.version }}
+          generate_release_notes: true
+          prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/CD-common-tag.yml
+++ b/.github/workflows/CD-common-tag.yml
@@ -1,0 +1,38 @@
+name: CD-common-tag
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Create release tag
+        run: |
+          set -euo pipefail
+
+          TAG="v${{ inputs.version }}"
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping."
+            exit 0
+          fi
+
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -114,40 +114,68 @@ jobs:
       id-token: write
     uses: ./.github/workflows/CD-docs-pages.yml
 
-  CD-tag:
+  CD-tag-rc:
     needs:
       - CD-version
       - CD-nuget-rc
       - CD-vsix-rc
+      - CD-docs-pages
+    if: |
+      always() &&
+      github.ref == 'refs/heads/master' &&
+      (inputs.release_channel == 'rc' || inputs.release_channel == 'both') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    uses: ./.github/workflows/CD-common-tag.yml
+    with:
+      version: ${{ needs.CD-version.outputs.version_rc }}
+    secrets: inherit
+
+  CD-github-release-rc:
+    needs:
+      - CD-version
+      - CD-tag-rc
+    if: |
+      always() &&
+      github.ref == 'refs/heads/master' &&
+      (inputs.release_channel == 'rc' || inputs.release_channel == 'both') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    uses: ./.github/workflows/CD-common-github-release.yml
+    with:
+      version: ${{ needs.CD-version.outputs.version_rc }}
+      prerelease: true
+    secrets: inherit
+
+  CD-tag-prod:
+    needs:
+      - CD-version
       - CD-nuget-prod
       - CD-vsix-prod
       - CD-docs-pages
     if: |
       always() &&
       github.ref == 'refs/heads/master' &&
+      (inputs.release_channel == 'prod' || inputs.release_channel == 'both') &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: true
+    uses: ./.github/workflows/CD-common-tag.yml
+    with:
+      version: ${{ needs.CD-version.outputs.version }}
+    secrets: inherit
 
-      - name: Create release tag
-        run: |
-          set -euo pipefail
-
-          TAG="v${{ needs.CD-version.outputs.version }}"
-
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping."
-            exit 0
-          fi
-
-          git tag "$TAG"
-          git push origin "$TAG"
+  CD-github-release-prod:
+    needs:
+      - CD-version
+      - CD-tag-prod
+    if: |
+      always() &&
+      github.ref == 'refs/heads/master' &&
+      (inputs.release_channel == 'prod' || inputs.release_channel == 'both') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    uses: ./.github/workflows/CD-common-github-release.yml
+    with:
+      version: ${{ needs.CD-version.outputs.version }}
+      prerelease: false
+    secrets: inherit


### PR DESCRIPTION
### Motivation

- Consolidate tag creation and GitHub release steps into reusable workflows to avoid duplication and standardize release behavior. 
- Split release flows for release-candidate and production channels so RCs are published as prereleases while prod releases are full releases.

### Description

- Add new reusable workflows `CD-common-tag.yml` to create and push a `v{version}` tag and `CD-common-github-release.yml` to create a GitHub release with `prerelease` control. 
- Refactor `.github/workflows/CD.yml` to call the new common workflows and replace inlined tag/release steps with `uses: ./.github/workflows/CD-common-tag.yml` and `uses: ./.github/workflows/CD-common-github-release.yml`. 
- Split the previous `CD-tag` job into `CD-tag-rc`/`CD-github-release-rc` and `CD-tag-prod`/`CD-github-release-prod` job pairs, wiring `version_rc` for RC releases and setting `prerelease: true` for RCs and `false` for prod. 
- Preserve existing permission settings and ensure jobs propagate `secrets: inherit` where needed.

### Testing

- No automated tests were executed as part of this change; the update only adds and reuses workflow YAML files and refactors job wiring in `CD.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1789a81d883249fce786943d9bf5e)