### PR TITLE
Add `includeTransitiveDependencies` config to control transitive project edges

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ solution: SlnxMermaid.slnx
 
 diagram:
   direction: TD   # TD (top-down) | LR (left-right)
+  includeTransitiveDependencies: true  # true = direct + indirect | false = direct only
 
 filters:
   exclude:
@@ -42,6 +43,11 @@ Path to `.sln` / `.slnx` file.
 ### `diagram.direction`
 - `TD` (top-down)
 - `LR` (left-right)
+
+### `diagram.includeTransitiveDependencies`
+- `true` (default): include both direct and indirect project dependencies.
+- `false`: include only direct project references.
+- If omitted from `slnx-mermaid.yml`, the default remains `true` for backward compatibility.
 
 ### `filters.exclude`
 Project name patterns to omit from the graph.

--- a/slnx-mermaid.yml
+++ b/slnx-mermaid.yml
@@ -5,6 +5,7 @@ solution: SlnxMermaid.slnx
 
 diagram:
   direction: TD   # TD (top-down) | LR (left-right)
+  includeTransitiveDependencies: true  # true = direct + indirect | false = direct only
 
 filters:
   exclude:

--- a/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
+++ b/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
@@ -32,7 +32,9 @@ public sealed class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
 
         AnsiConsole.MarkupLine($"[green]Using config[/]: [grey]{Path.GetFileName(configPath)}[/]");
 
-        var nodes = SolutionGraphAnalyzer.Analyze(config.Solution);
+        var nodes = SolutionGraphAnalyzer.Analyze(
+            config.Solution,
+            config.Diagram.IncludeTransitiveDependencies);
 
         var naming = new NameTransformer(config.Naming);
 

--- a/src/SlnxMermaid.Core/Config/DiagramConfig.cs
+++ b/src/SlnxMermaid.Core/Config/DiagramConfig.cs
@@ -3,5 +3,7 @@
 public sealed class DiagramConfig
 {
     public string Direction { get; set; } = "TD";
+
+    public bool IncludeTransitiveDependencies { get; set; } = true;
 }
 }

--- a/src/SlnxMermaid.Core/Graph/SolutionGraphAnalyzer.cs
+++ b/src/SlnxMermaid.Core/Graph/SolutionGraphAnalyzer.cs
@@ -10,6 +10,13 @@ namespace SlnxMermaid.Core.Graph
     {
         public static IReadOnlyCollection<ProjectNode> Analyze(string solutionPath)
         {
+            return Analyze(solutionPath, includeTransitiveDependencies: true);
+        }
+
+        public static IReadOnlyCollection<ProjectNode> Analyze(
+            string solutionPath,
+            bool includeTransitiveDependencies)
+        {
             var graph = new ProjectGraph(solutionPath);
 
             var nodes = graph.ProjectNodes
@@ -26,11 +33,11 @@ namespace SlnxMermaid.Core.Graph
             {
                 var from = byPath[node.ProjectInstance.FullPath];
 
-                foreach (var dep in node.ProjectReferences)
+                foreach (var dependencyPath in GetDirectProjectReferencePaths(node))
                 {
                     ProjectNode to;
 
-                    if (byPath.TryGetValue(dep.ProjectInstance.FullPath, out to))
+                    if (byPath.TryGetValue(dependencyPath, out to))
                     {
                         if (!StringComparer.OrdinalIgnoreCase.Equals(from.Path, to.Path))
                         {
@@ -40,7 +47,56 @@ namespace SlnxMermaid.Core.Graph
                 }
             }
 
+            if (includeTransitiveDependencies)
+                AddTransitiveDependencies(nodes);
+
             return nodes;
+        }
+
+        private static IEnumerable<string> GetDirectProjectReferencePaths(ProjectGraphNode node)
+        {
+            var projectDirectory = Path.GetDirectoryName(node.ProjectInstance.FullPath);
+
+            foreach (var projectReference in node.ProjectInstance.GetItems("ProjectReference"))
+            {
+                var include = projectReference.EvaluatedInclude;
+
+                if (string.IsNullOrWhiteSpace(include))
+                    continue;
+
+                yield return Path.GetFullPath(Path.Combine(projectDirectory, include));
+            }
+        }
+
+        private static void AddTransitiveDependencies(IEnumerable<ProjectNode> nodes)
+        {
+            foreach (var node in nodes)
+            {
+                foreach (var dependency in GetTransitiveDependencies(node))
+                {
+                    if (!StringComparer.OrdinalIgnoreCase.Equals(node.Path, dependency.Path))
+                        node.Dependencies.Add(dependency);
+                }
+            }
+        }
+
+        private static IEnumerable<ProjectNode> GetTransitiveDependencies(ProjectNode node)
+        {
+            var visited = new HashSet<ProjectNode>();
+            var stack = new Stack<ProjectNode>(node.Dependencies);
+
+            while (stack.Count > 0)
+            {
+                var dependency = stack.Pop();
+
+                if (!visited.Add(dependency))
+                    continue;
+
+                yield return dependency;
+
+                foreach (var transitiveDependency in dependency.Dependencies)
+                    stack.Push(transitiveDependency);
+            }
         }
 
         private static string ToId(string projectPath)

--- a/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
+++ b/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
@@ -53,7 +53,9 @@ namespace SlnxMermaidVsix
             await outputService.LogAsync(pane,
                 string.Format(Strings.LogAnalyzingSolutionFormat, config.Solution));
 
-            var nodes = SolutionGraphAnalyzer.Analyze(config.Solution);
+            var nodes = SolutionGraphAnalyzer.Analyze(
+                config.Solution,
+                config.Diagram.IncludeTransitiveDependencies);
 
             await outputService.LogAsync(pane,
                 string.Format(Strings.LogDiscoveredProjectsFormat, nodes.Count));

--- a/tests/SlnxMermaid.UnitTests/Config/ConfigDefaultsTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/ConfigDefaultsTests.cs
@@ -24,6 +24,14 @@ public class ConfigDefaultsTests
     }
 
     [Fact]
+    public void DiagramConfig_DefaultIncludeTransitiveDependencies_ShouldBeTrue()
+    {
+        var config = new DiagramConfig();
+
+        Assert.True(config.IncludeTransitiveDependencies);
+    }
+
+    [Fact]
     public void FilterConfig_DefaultExclude_ShouldBeEmptyList()
     {
         var config = new FilterConfig();

--- a/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
@@ -16,6 +16,7 @@ output:
   file: ./out/diagram.md
 diagram:
   direction: LR
+  includeTransitiveDependencies: false
 filters:
   exclude:
     - Test
@@ -30,9 +31,34 @@ naming:
             Assert.Equal("./src/sample.slnx", result.Solution);
             Assert.Equal("./out/diagram.md", result.Output.File);
             Assert.Equal("LR", result.Diagram.Direction);
+            Assert.False(result.Diagram.IncludeTransitiveDependencies);
             Assert.Single(result.Filters.Exclude);
             Assert.Equal("Company.", result.Naming.StripPrefix);
             Assert.Equal("S", result.Naming.Aliases["Sample"]);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Load_WhenIncludeTransitiveDependenciesIsMissing_ShouldUseDefaultTrue()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, """
+solution: ./src/sample.slnx
+diagram:
+  direction: LR
+output:
+  file: ./out/diagram.md
+""");
+
+            var result = YamlConfigLoader.Load(path);
+
+            Assert.True(result.Diagram.IncludeTransitiveDependencies);
         }
         finally
         {

--- a/tests/SlnxMermaid.UnitTests/Graph/SolutionGraphAnalyzer.AnalyzeTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Graph/SolutionGraphAnalyzer.AnalyzeTests.cs
@@ -19,36 +19,9 @@ public class SolutionGraphAnalyzerAnalyzeTests
 
         try
         {
-            var projectB = Path.Combine(root, "Project.B", "Project.B.csproj");
-            Directory.CreateDirectory(Path.GetDirectoryName(projectB)!);
-            File.WriteAllText(projectB, """
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
-</Project>
-""");
-
-            var projectA = Path.Combine(root, "Project.A", "Project.A.csproj");
-            Directory.CreateDirectory(Path.GetDirectoryName(projectA)!);
-            File.WriteAllText(projectA, $"""
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..{Path.DirectorySeparatorChar}Project.B{Path.DirectorySeparatorChar}Project.B.csproj" />
-  </ItemGroup>
-</Project>
-""");
-
-            var solution = Path.Combine(root, "sample.slnx");
-            File.WriteAllText(solution, $"""
-<Solution>
-  <Project Path="Project.A{Path.DirectorySeparatorChar}Project.A.csproj" />
-  <Project Path="Project.B{Path.DirectorySeparatorChar}Project.B.csproj" />
-</Solution>
-""");
+            var projectB = WriteProject(root, "Project.B");
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB);
 
             var nodes = SolutionGraphAnalyzer.Analyze(solution);
             var a = Assert.Single(nodes, n => n.Id == "Project_A");
@@ -60,5 +33,109 @@ public class SolutionGraphAnalyzerAnalyzeTests
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Fact]
+    public void Analyze_WhenTransitiveDependenciesAreIncluded_ShouldCreateIndirectDependencyEdge()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectC = WriteProject(root, "Project.C");
+            var projectB = WriteProject(root, "Project.B", projectC);
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB, projectC);
+
+            var nodes = SolutionGraphAnalyzer.Analyze(solution, includeTransitiveDependencies: true);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+            var c = Assert.Single(nodes, n => n.Id == "Project_C");
+
+            Assert.Contains(b, a.Dependencies);
+            Assert.Contains(c, a.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Analyze_WhenTransitiveDependenciesAreExcluded_ShouldOnlyCreateDirectDependencyEdges()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectC = WriteProject(root, "Project.C");
+            var projectB = WriteProject(root, "Project.B", projectC);
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB, projectC);
+
+            var nodes = SolutionGraphAnalyzer.Analyze(solution, includeTransitiveDependencies: false);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+            var c = Assert.Single(nodes, n => n.Id == "Project_C");
+
+            Assert.Contains(b, a.Dependencies);
+            Assert.DoesNotContain(c, a.Dependencies);
+            Assert.Contains(c, b.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string WriteProject(
+        string root,
+        string projectName,
+        params string[] projectReferences)
+    {
+        var projectPath = Path.Combine(root, projectName, $"{projectName}.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+
+        var references = string.Join(
+            Environment.NewLine,
+            projectReferences.Select(reference =>
+                $"    <ProjectReference Include=\"{Path.GetRelativePath(Path.GetDirectoryName(projectPath)!, reference)}\" />"));
+
+        var itemGroup = projectReferences.Length == 0
+            ? string.Empty
+            : $"""
+  <ItemGroup>
+{references}
+  </ItemGroup>
+""";
+
+        File.WriteAllText(projectPath, $"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+{itemGroup}</Project>
+""");
+
+        return projectPath;
+    }
+
+    private static string WriteSolution(string root, params string[] projects)
+    {
+        var solution = Path.Combine(root, "sample.slnx");
+        var projectEntries = string.Join(
+            Environment.NewLine,
+            projects.Select(project =>
+                $"  <Project Path=\"{Path.GetRelativePath(root, project)}\" />"));
+
+        File.WriteAllText(solution, $"""
+<Solution>
+{projectEntries}
+</Solution>
+""");
+
+        return solution;
     }
 }


### PR DESCRIPTION
### Motivation
- Allow users to control whether generated dependency graphs include indirect (transitive) project references or only direct references.
- Preserve backward compatibility by making the new option default to `true` and documenting the behavior in the config reference.

### Description
- Added `IncludeTransitiveDependencies` boolean to `DiagramConfig` with a default value of `true` and updated example config files and docs to describe the option.
- Extended `SolutionGraphAnalyzer` with an overload `Analyze(string, bool)` and implemented `GetDirectProjectReferencePaths`, `AddTransitiveDependencies`, and `GetTransitiveDependencies` to optionally compute transitive edges.
- Wired the new option through the tooling by passing `config.Diagram.IncludeTransitiveDependencies` from `GenerateCommand` and `MermaidDiagramGenerator` to the analyzer.
- Updated and added unit tests and helpers to validate default config values, YAML deserialization of the new option, and analyzer behavior for included and excluded transitive dependencies.

### Testing
- Ran unit tests in the `SlnxMermaid.UnitTests` test project, including `ConfigDefaultsTests`, `YamlConfigLoaderLoadTests`, and `SolutionGraphAnalyzerAnalyzeTests`, and they all passed.
- New tests verify that `DiagramConfig.IncludeTransitiveDependencies` defaults to `true` and that `SolutionGraphAnalyzer.Analyze` produces correct direct-only and transitive-inclusive edges.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5ddee52c83249deba51060ef3b96)