### PR TITLE
Add `includeTransitiveDependencies` option and transitive dependency analysis

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ solution: SlnxMermaid.slnx
 
 diagram:
   direction: TD   # TD (top-down) | LR (left-right)
+  includeTransitiveDependencies: false  # false = direct only | true = direct + indirect
 
 filters:
   exclude:
@@ -42,6 +43,11 @@ Path to `.sln` / `.slnx` file.
 ### `diagram.direction`
 - `TD` (top-down)
 - `LR` (left-right)
+
+### `diagram.includeTransitiveDependencies`
+- `false` (default): include only direct project references.
+- `true`: include both direct and indirect project dependencies.
+- If omitted from `slnx-mermaid.yml`, the default remains `false` to keep diagrams focused on explicit project references.
 
 ### `filters.exclude`
 Project name patterns to omit from the graph.

--- a/slnx-mermaid.yml
+++ b/slnx-mermaid.yml
@@ -5,6 +5,7 @@ solution: SlnxMermaid.slnx
 
 diagram:
   direction: TD   # TD (top-down) | LR (left-right)
+  includeTransitiveDependencies: false  # false = direct only | true = direct + indirect
 
 filters:
   exclude:

--- a/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
+++ b/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
@@ -32,7 +32,7 @@ public sealed class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
 
         AnsiConsole.MarkupLine($"[green]Using config[/]: [grey]{Path.GetFileName(configPath)}[/]");
 
-        var nodes = SolutionGraphAnalyzer.Analyze(config.Solution);
+        var nodes = SolutionGraphAnalyzer.Analyze(config);
 
         var naming = new NameTransformer(config.Naming);
 

--- a/src/SlnxMermaid.Core/Config/DiagramConfig.cs
+++ b/src/SlnxMermaid.Core/Config/DiagramConfig.cs
@@ -3,5 +3,7 @@
 public sealed class DiagramConfig
 {
     public string Direction { get; set; } = "TD";
+
+    public bool IncludeTransitiveDependencies { get; set; } = false;
 }
 }

--- a/src/SlnxMermaid.Core/Graph/SolutionGraphAnalyzer.cs
+++ b/src/SlnxMermaid.Core/Graph/SolutionGraphAnalyzer.cs
@@ -3,12 +3,32 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Graph;
+using SlnxMermaid.Core.Config;
 
 namespace SlnxMermaid.Core.Graph
 {
     public static class SolutionGraphAnalyzer
     {
+        private const string ProjectReferenceItemName = "ProjectReference";
+
+        public static IReadOnlyCollection<ProjectNode> Analyze(SlnxMermaidConfig config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            return Analyze(
+                config.Solution,
+                config.Diagram != null && config.Diagram.IncludeTransitiveDependencies);
+        }
+
         public static IReadOnlyCollection<ProjectNode> Analyze(string solutionPath)
+        {
+            return Analyze(solutionPath, includeTransitiveDependencies: false);
+        }
+
+        public static IReadOnlyCollection<ProjectNode> Analyze(
+            string solutionPath,
+            bool includeTransitiveDependencies)
         {
             var graph = new ProjectGraph(solutionPath);
 
@@ -26,11 +46,11 @@ namespace SlnxMermaid.Core.Graph
             {
                 var from = byPath[node.ProjectInstance.FullPath];
 
-                foreach (var dep in node.ProjectReferences)
+                foreach (var dependencyPath in GetDirectProjectReferencePaths(node))
                 {
                     ProjectNode to;
 
-                    if (byPath.TryGetValue(dep.ProjectInstance.FullPath, out to))
+                    if (byPath.TryGetValue(dependencyPath, out to))
                     {
                         if (!StringComparer.OrdinalIgnoreCase.Equals(from.Path, to.Path))
                         {
@@ -40,10 +60,59 @@ namespace SlnxMermaid.Core.Graph
                 }
             }
 
+            if (includeTransitiveDependencies)
+                AddTransitiveDependencies(nodes);
+
             return nodes;
         }
 
-        private static string ToId(string projectPath)
+        internal static IEnumerable<string> GetDirectProjectReferencePaths(ProjectGraphNode node)
+        {
+            var projectDirectory = Path.GetDirectoryName(node.ProjectInstance.FullPath);
+
+            foreach (var projectReference in node.ProjectInstance.GetItems(ProjectReferenceItemName))
+            {
+                var include = projectReference.EvaluatedInclude;
+
+                if (string.IsNullOrWhiteSpace(include))
+                    continue;
+
+                yield return Path.GetFullPath(Path.Combine(projectDirectory, include));
+            }
+        }
+
+        internal static void AddTransitiveDependencies(IEnumerable<ProjectNode> nodes)
+        {
+            foreach (var node in nodes)
+            {
+                foreach (var dependency in GetTransitiveDependencies(node))
+                {
+                    if (!StringComparer.OrdinalIgnoreCase.Equals(node.Path, dependency.Path))
+                        node.Dependencies.Add(dependency);
+                }
+            }
+        }
+
+        internal static IEnumerable<ProjectNode> GetTransitiveDependencies(ProjectNode node)
+        {
+            var visited = new HashSet<ProjectNode>();
+            var stack = new Stack<ProjectNode>(node.Dependencies);
+
+            while (stack.Count > 0)
+            {
+                var dependency = stack.Pop();
+
+                if (!visited.Add(dependency))
+                    continue;
+
+                yield return dependency;
+
+                foreach (var transitiveDependency in dependency.Dependencies)
+                    stack.Push(transitiveDependency);
+            }
+        }
+
+        internal static string ToId(string projectPath)
         {
             return Path.GetFileNameWithoutExtension(projectPath)
                 .Replace('.', '_')

--- a/src/SlnxMermaid.Core/Properties/AssemblyInfo.cs
+++ b/src/SlnxMermaid.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SlnxMermaid.UnitTests")]

--- a/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
+++ b/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
@@ -53,7 +53,7 @@ namespace SlnxMermaidVsix
             await outputService.LogAsync(pane,
                 string.Format(Strings.LogAnalyzingSolutionFormat, config.Solution));
 
-            var nodes = SolutionGraphAnalyzer.Analyze(config.Solution);
+            var nodes = SolutionGraphAnalyzer.Analyze(config);
 
             await outputService.LogAsync(pane,
                 string.Format(Strings.LogDiscoveredProjectsFormat, nodes.Count));

--- a/tests/SlnxMermaid.UnitTests/Config/ConfigDefaultsTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/ConfigDefaultsTests.cs
@@ -24,6 +24,14 @@ public class ConfigDefaultsTests
     }
 
     [Fact]
+    public void DiagramConfig_DefaultIncludeTransitiveDependencies_ShouldBeFalse()
+    {
+        var config = new DiagramConfig();
+
+        Assert.False(config.IncludeTransitiveDependencies);
+    }
+
+    [Fact]
     public void FilterConfig_DefaultExclude_ShouldBeEmptyList()
     {
         var config = new FilterConfig();

--- a/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
@@ -7,37 +7,27 @@ public class YamlConfigLoaderLoadTests
     [Fact]
     public void Load_WhenYamlIsValid_ShouldDeserializeConfig()
     {
-        var path = Path.GetTempFileName();
-        try
-        {
-            File.WriteAllText(path, """
-solution: ./src/sample.slnx
-output:
-  file: ./out/diagram.md
-diagram:
-  direction: LR
-filters:
-  exclude:
-    - Test
-naming:
-  stripPrefix: Company.
-  aliases:
-    Sample: S
-""");
+        var path = GetConfigPath("valid-config.yml");
 
-            var result = YamlConfigLoader.Load(path);
+        var result = YamlConfigLoader.Load(path);
 
-            Assert.Equal("./src/sample.slnx", result.Solution);
-            Assert.Equal("./out/diagram.md", result.Output.File);
-            Assert.Equal("LR", result.Diagram.Direction);
-            Assert.Single(result.Filters.Exclude);
-            Assert.Equal("Company.", result.Naming.StripPrefix);
-            Assert.Equal("S", result.Naming.Aliases["Sample"]);
-        }
-        finally
-        {
-            File.Delete(path);
-        }
+        Assert.Equal("./src/sample.slnx", result.Solution);
+        Assert.Equal("./out/diagram.md", result.Output.File);
+        Assert.Equal("LR", result.Diagram.Direction);
+        Assert.False(result.Diagram.IncludeTransitiveDependencies);
+        Assert.Single(result.Filters.Exclude);
+        Assert.Equal("Company.", result.Naming.StripPrefix);
+        Assert.Equal("S", result.Naming.Aliases["Sample"]);
+    }
+
+    [Fact]
+    public void Load_WhenIncludeTransitiveDependenciesIsMissing_ShouldUseDefaultFalse()
+    {
+        var path = GetConfigPath("missing-transitive-dependencies-config.yml");
+
+        var result = YamlConfigLoader.Load(path);
+
+        Assert.False(result.Diagram.IncludeTransitiveDependencies);
     }
 
     [Fact]
@@ -47,4 +37,7 @@ naming:
 
         Assert.Throws<FileNotFoundException>(() => YamlConfigLoader.Load(path));
     }
+
+    private static string GetConfigPath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", "Config", fileName);
 }

--- a/tests/SlnxMermaid.UnitTests/Graph/SolutionGraphAnalyzer.AnalyzeTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Graph/SolutionGraphAnalyzer.AnalyzeTests.cs
@@ -1,4 +1,6 @@
+using Microsoft.Build.Graph;
 using Microsoft.Build.Locator;
+using SlnxMermaid.Core.Config;
 using SlnxMermaid.Core.Graph;
 
 namespace SlnxMermaid.UnitTests.Graph;
@@ -19,36 +21,9 @@ public class SolutionGraphAnalyzerAnalyzeTests
 
         try
         {
-            var projectB = Path.Combine(root, "Project.B", "Project.B.csproj");
-            Directory.CreateDirectory(Path.GetDirectoryName(projectB)!);
-            File.WriteAllText(projectB, """
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
-</Project>
-""");
-
-            var projectA = Path.Combine(root, "Project.A", "Project.A.csproj");
-            Directory.CreateDirectory(Path.GetDirectoryName(projectA)!);
-            File.WriteAllText(projectA, $"""
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..{Path.DirectorySeparatorChar}Project.B{Path.DirectorySeparatorChar}Project.B.csproj" />
-  </ItemGroup>
-</Project>
-""");
-
-            var solution = Path.Combine(root, "sample.slnx");
-            File.WriteAllText(solution, $"""
-<Solution>
-  <Project Path="Project.A{Path.DirectorySeparatorChar}Project.A.csproj" />
-  <Project Path="Project.B{Path.DirectorySeparatorChar}Project.B.csproj" />
-</Solution>
-""");
+            var projectB = WriteProject(root, "Project.B");
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB);
 
             var nodes = SolutionGraphAnalyzer.Analyze(solution);
             var a = Assert.Single(nodes, n => n.Id == "Project_A");
@@ -60,5 +35,243 @@ public class SolutionGraphAnalyzerAnalyzeTests
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Fact]
+    public void Analyze_WhenTransitiveDependenciesAreIncluded_ShouldCreateIndirectDependencyEdge()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectC = WriteProject(root, "Project.C");
+            var projectB = WriteProject(root, "Project.B", projectC);
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB, projectC);
+
+            var nodes = SolutionGraphAnalyzer.Analyze(solution, includeTransitiveDependencies: true);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+            var c = Assert.Single(nodes, n => n.Id == "Project_C");
+
+            Assert.Contains(b, a.Dependencies);
+            Assert.Contains(c, a.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Analyze_WhenTransitiveDependenciesAreExcluded_ShouldOnlyCreateDirectDependencyEdges()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectC = WriteProject(root, "Project.C");
+            var projectB = WriteProject(root, "Project.B", projectC);
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB, projectC);
+
+            var nodes = SolutionGraphAnalyzer.Analyze(solution, includeTransitiveDependencies: false);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+            var c = Assert.Single(nodes, n => n.Id == "Project_C");
+
+            Assert.Contains(b, a.Dependencies);
+            Assert.DoesNotContain(c, a.Dependencies);
+            Assert.Contains(c, b.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Analyze_WhenTransitiveDependencyOptionIsOmitted_ShouldOnlyCreateDirectDependencyEdges()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectC = WriteProject(root, "Project.C");
+            var projectB = WriteProject(root, "Project.B", projectC);
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB, projectC);
+
+            var nodes = SolutionGraphAnalyzer.Analyze(solution);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+            var c = Assert.Single(nodes, n => n.Id == "Project_C");
+
+            Assert.Contains(b, a.Dependencies);
+            Assert.DoesNotContain(c, a.Dependencies);
+            Assert.Contains(c, b.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Analyze_WhenConfigEnablesTransitiveDependencies_ShouldCreateIndirectDependencyEdge()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectC = WriteProject(root, "Project.C");
+            var projectB = WriteProject(root, "Project.B", projectC);
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB, projectC);
+            var config = new SlnxMermaidConfig
+            {
+                Solution = solution,
+                Diagram = new DiagramConfig
+                {
+                    IncludeTransitiveDependencies = true
+                }
+            };
+
+            var nodes = SolutionGraphAnalyzer.Analyze(config);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+            var c = Assert.Single(nodes, n => n.Id == "Project_C");
+
+            Assert.Contains(b, a.Dependencies);
+            Assert.Contains(c, a.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Analyze_WhenConfigIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => SolutionGraphAnalyzer.Analyze((SlnxMermaidConfig)null!));
+    }
+
+    [Fact]
+    public void GetTransitiveDependencies_WhenNodeHasNestedDependencies_ShouldReturnDirectAndIndirectDependencies()
+    {
+        var a = new ProjectNode("A", "A.csproj");
+        var b = new ProjectNode("B", "B.csproj");
+        var c = new ProjectNode("C", "C.csproj");
+        a.Dependencies.Add(b);
+        b.Dependencies.Add(c);
+
+        var dependencies = SolutionGraphAnalyzer.GetTransitiveDependencies(a).ToList();
+
+        Assert.Contains(b, dependencies);
+        Assert.Contains(c, dependencies);
+    }
+
+    [Fact]
+    public void AddTransitiveDependencies_WhenCycleExists_ShouldAddIndirectDependenciesWithoutSelfReference()
+    {
+        var a = new ProjectNode("A", "A.csproj");
+        var b = new ProjectNode("B", "B.csproj");
+        var c = new ProjectNode("C", "C.csproj");
+        a.Dependencies.Add(b);
+        b.Dependencies.Add(c);
+        c.Dependencies.Add(a);
+
+        SolutionGraphAnalyzer.AddTransitiveDependencies([a, b, c]);
+
+        Assert.Contains(c, a.Dependencies);
+        Assert.DoesNotContain(a, a.Dependencies);
+    }
+
+    [Fact]
+    public void GetDirectProjectReferencePaths_WhenProjectHasReference_ShouldResolveReferencePath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectB = WriteProject(root, "Project.B");
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB);
+            var graph = new ProjectGraph(solution);
+            var node = Assert.Single(
+                graph.ProjectNodes,
+                n => StringComparer.OrdinalIgnoreCase.Equals(n.ProjectInstance.FullPath, projectA));
+
+            var references = SolutionGraphAnalyzer.GetDirectProjectReferencePaths(node).ToList();
+
+            Assert.Contains(projectB, references, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ToId_WhenProjectNameContainsSeparators_ShouldNormalizeName()
+    {
+        var result = SolutionGraphAnalyzer.ToId(Path.Combine("src", "Company.Project-Api.csproj"));
+
+        Assert.Equal("Company_Project_Api", result);
+    }
+
+    private static string WriteProject(
+        string root,
+        string projectName,
+        params string[] projectReferences)
+    {
+        var projectPath = Path.Combine(root, projectName, $"{projectName}.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+
+        var references = string.Join(
+            Environment.NewLine,
+            projectReferences.Select(reference =>
+                $"    <ProjectReference Include=\"{Path.GetRelativePath(Path.GetDirectoryName(projectPath)!, reference)}\" />"));
+
+        var itemGroup = projectReferences.Length == 0
+            ? string.Empty
+            : $"""
+  <ItemGroup>
+{references}
+  </ItemGroup>
+""";
+
+        File.WriteAllText(projectPath, $"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+{itemGroup}</Project>
+""");
+
+        return projectPath;
+    }
+
+    private static string WriteSolution(string root, params string[] projects)
+    {
+        var solution = Path.Combine(root, "sample.slnx");
+        var projectEntries = string.Join(
+            Environment.NewLine,
+            projects.Select(project =>
+                $"  <Project Path=\"{Path.GetRelativePath(root, project)}\" />"));
+
+        File.WriteAllText(solution, $"""
+<Solution>
+{projectEntries}
+</Solution>
+""");
+
+        return solution;
     }
 }

--- a/tests/SlnxMermaid.UnitTests/SlnxMermaid.UnitTests.csproj
+++ b/tests/SlnxMermaid.UnitTests/SlnxMermaid.UnitTests.csproj
@@ -12,6 +12,11 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
+    <PackageReference Include="Microsoft.Build" Version="18.3.3">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
 	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -27,6 +32,10 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="TestData\Config\*.yml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/missing-transitive-dependencies-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/missing-transitive-dependencies-config.yml
@@ -1,0 +1,5 @@
+solution: ./src/sample.slnx
+diagram:
+  direction: LR
+output:
+  file: ./out/diagram.md

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/valid-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/valid-config.yml
@@ -1,0 +1,13 @@
+solution: ./src/sample.slnx
+output:
+  file: ./out/diagram.md
+diagram:
+  direction: LR
+  includeTransitiveDependencies: false
+filters:
+  exclude:
+    - Test
+naming:
+  stripPrefix: Company.
+  aliases:
+    Sample: S


### PR DESCRIPTION
### Motivation

- Allow diagrams to optionally include indirect (transitive) project dependencies instead of only direct `ProjectReference` edges.
- Provide a config-driven way to control inclusion of transitive dependencies so generated graphs can be more or less verbose as desired.

### Description

- Added `IncludeTransitiveDependencies` boolean to `DiagramConfig` with default `false` and documented the option in `docs/configuration.md` and `slnx-mermaid.yml` example. 
- Extended `SolutionGraphAnalyzer` to accept either a `SlnxMermaidConfig` or a solution path and to collect direct references via `GetDirectProjectReferencePaths`, compute transitive closures via `GetTransitiveDependencies`, and apply them with `AddTransitiveDependencies` when enabled. 
- Updated callers to pass the full config to the analyzer (`GenerateCommand` and `MermaidDiagramGenerator`) so the new option can be honored. 
- Added `InternalsVisibleTo` for unit tests, added `Microsoft.Build` test dependency, included YAML test fixtures under `TestData`, and added comprehensive unit tests covering config defaults, YAML loading, and analyzer behavior (direct vs transitive dependency cases). 

### Testing

- Ran the `SlnxMermaid.UnitTests` test suite including `ConfigDefaultsTests`, `YamlConfigLoaderLoadTests`, and `SolutionGraphAnalyzerAnalyzeTests`, and all tests passed. 
- Tests added verify that `DiagramConfig.IncludeTransitiveDependencies` defaults to `false`, that YAML files without the option use the default, and that `SolutionGraphAnalyzer` produces direct-only or direct+indirect edges according to the option.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5ddee52c83249deba51060ef3b96)