### PR TITLE
Handle MSBuild project graph evaluation failures

### DIFF
--- a/src/SlnxMermaid.Core/Graph/SolutionGraphAnalyzer.cs
+++ b/src/SlnxMermaid.Core/Graph/SolutionGraphAnalyzer.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Microsoft.Build.Exceptions;
 using Microsoft.Build.Graph;
 using SlnxMermaid.Core.Config;
 
@@ -30,23 +33,74 @@ namespace SlnxMermaid.Core.Graph
             string solutionPath,
             bool includeTransitiveDependencies)
         {
-            var graph = new ProjectGraph(solutionPath);
+            try
+            {
+                var graph = new ProjectGraph(solutionPath);
 
+                return AnalyzeProjectGraph(graph, includeTransitiveDependencies);
+            }
+            catch (Exception exception) when (IsProjectEvaluationFailure(exception))
+            {
+                return AnalyzeSolutionFile(solutionPath, includeTransitiveDependencies);
+            }
+        }
+
+        internal static IReadOnlyCollection<ProjectNode> AnalyzeProjectGraph(
+            ProjectGraph graph,
+            bool includeTransitiveDependencies)
+        {
             var nodes = graph.ProjectNodes
                 .Select(n => new ProjectNode(
                     ToId(n.ProjectInstance.FullPath),
                     n.ProjectInstance.FullPath))
                 .ToList();
 
+            AddDirectDependencies(nodes, graph.ProjectNodes, GetDirectProjectReferencePaths);
+
+            if (includeTransitiveDependencies)
+                AddTransitiveDependencies(nodes);
+
+            return nodes;
+        }
+
+        internal static IReadOnlyCollection<ProjectNode> AnalyzeSolutionFile(
+            string solutionPath,
+            bool includeTransitiveDependencies)
+        {
+            var projectPaths = GetSolutionProjectPaths(solutionPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var nodes = projectPaths
+                .Select(projectPath => new ProjectNode(ToId(projectPath), projectPath))
+                .ToList();
+
+            AddDirectDependencies(nodes, projectPaths, GetDirectProjectReferencePaths);
+
+            if (includeTransitiveDependencies)
+                AddTransitiveDependencies(nodes);
+
+            return nodes;
+        }
+
+        internal static void AddDirectDependencies<TProject>(
+            IEnumerable<ProjectNode> nodes,
+            IEnumerable<TProject> projects,
+            Func<TProject, IEnumerable<string>> getDirectProjectReferencePaths)
+        {
             var byPath = nodes
                 .GroupBy(n => n.Path, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
-            foreach (var node in graph.ProjectNodes)
+            foreach (var project in projects)
             {
-                var from = byPath[node.ProjectInstance.FullPath];
+                ProjectNode from;
+                var projectPath = GetProjectPath(project);
 
-                foreach (var dependencyPath in GetDirectProjectReferencePaths(node))
+                if (!byPath.TryGetValue(projectPath, out from))
+                    continue;
+
+                foreach (var dependencyPath in getDirectProjectReferencePaths(project))
                 {
                     ProjectNode to;
 
@@ -59,11 +113,87 @@ namespace SlnxMermaid.Core.Graph
                     }
                 }
             }
+        }
 
-            if (includeTransitiveDependencies)
-                AddTransitiveDependencies(nodes);
+        internal static bool IsProjectEvaluationFailure(Exception exception)
+        {
+            var aggregateException = exception as AggregateException;
 
-            return nodes;
+            if (aggregateException != null)
+                return aggregateException.Flatten().InnerExceptions.Any(IsProjectEvaluationFailure);
+
+            return exception is InvalidProjectFileException;
+        }
+
+        internal static IEnumerable<string> GetSolutionProjectPaths(string solutionPath)
+        {
+            var extension = Path.GetExtension(solutionPath);
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(extension, ".slnx"))
+                return GetSlnxProjectPaths(solutionPath);
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(extension, ".sln"))
+                return GetSlnProjectPaths(solutionPath);
+
+            return Enumerable.Empty<string>();
+        }
+
+        internal static IEnumerable<string> GetSlnxProjectPaths(string solutionPath)
+        {
+            var solutionDirectory = Path.GetDirectoryName(solutionPath);
+            var document = XDocument.Load(solutionPath);
+
+            return document
+                .Descendants()
+                .Where(element => StringComparer.OrdinalIgnoreCase.Equals(element.Name.LocalName, "Project"))
+                .Select(element => GetAttributeValue(element, "Path"))
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Select(path => Path.GetFullPath(Path.Combine(solutionDirectory, path)));
+        }
+
+        internal static IEnumerable<string> GetSlnProjectPaths(string solutionPath)
+        {
+            var solutionDirectory = Path.GetDirectoryName(solutionPath);
+            var projectPathPattern = new Regex(
+                "^Project\\(\"[^\"]+\"\\)\\s*=\\s*\"[^\"]+\"\\s*,\\s*\"(?<path>[^\"]+\\.(?:csproj|fsproj|vbproj))\"",
+                RegexOptions.IgnoreCase);
+
+            return File.ReadLines(solutionPath)
+                .Select(line => projectPathPattern.Match(line))
+                .Where(match => match.Success)
+                .Select(match => match.Groups["path"].Value)
+                .Select(path => Path.GetFullPath(Path.Combine(solutionDirectory, path)));
+        }
+
+        internal static IEnumerable<string> GetDirectProjectReferencePaths(string projectPath)
+        {
+            var projectDirectory = Path.GetDirectoryName(projectPath);
+            var document = XDocument.Load(projectPath);
+
+            return document
+                .Descendants()
+                .Where(element => StringComparer.OrdinalIgnoreCase.Equals(element.Name.LocalName, ProjectReferenceItemName))
+                .Select(element => GetAttributeValue(element, "Include"))
+                .Where(include => !string.IsNullOrWhiteSpace(include))
+                .Select(include => Path.GetFullPath(Path.Combine(projectDirectory, include)));
+        }
+
+        private static string GetProjectPath<TProject>(TProject project)
+        {
+            var node = project as ProjectGraphNode;
+
+            if (node != null)
+                return node.ProjectInstance.FullPath;
+
+            return project as string;
+        }
+
+        private static string GetAttributeValue(XElement element, string name)
+        {
+            var attribute = element.Attributes()
+                .FirstOrDefault(current => StringComparer.OrdinalIgnoreCase.Equals(current.Name.LocalName, name));
+
+            return attribute == null ? null : attribute.Value;
         }
 
         internal static IEnumerable<string> GetDirectProjectReferencePaths(ProjectGraphNode node)

--- a/tests/SlnxMermaid.UnitTests/Graph/SolutionGraphAnalyzer.AnalyzeTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Graph/SolutionGraphAnalyzer.AnalyzeTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Build.Exceptions;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Locator;
 using SlnxMermaid.Core.Config;
@@ -219,6 +220,64 @@ public class SolutionGraphAnalyzerAnalyzeTests
     }
 
     [Fact]
+    public void AnalyzeSolutionFile_WhenSlnxContainsProjectReference_ShouldCreateDependencyEdgeWithoutMsBuildEvaluation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectB = WriteProject(root, "Project.B");
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteSolution(root, projectA, projectB);
+
+            var nodes = SolutionGraphAnalyzer.AnalyzeSolutionFile(solution, includeTransitiveDependencies: false);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+
+            Assert.Contains(b, a.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AnalyzeSolutionFile_WhenSlnContainsProjectReference_ShouldCreateDependencyEdgeWithoutMsBuildEvaluation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-{Guid.NewGuid()}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectB = WriteProject(root, "Project.B");
+            var projectA = WriteProject(root, "Project.A", projectB);
+            var solution = WriteLegacySolution(root, projectA, projectB);
+
+            var nodes = SolutionGraphAnalyzer.AnalyzeSolutionFile(solution, includeTransitiveDependencies: false);
+            var a = Assert.Single(nodes, n => n.Id == "Project_A");
+            var b = Assert.Single(nodes, n => n.Id == "Project_B");
+
+            Assert.Contains(b, a.Dependencies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsProjectEvaluationFailure_WhenAggregateContainsInvalidProjectFileException_ShouldReturnTrue()
+    {
+        var exception = new AggregateException(new InvalidProjectFileException("sample.csproj"));
+
+        var result = SolutionGraphAnalyzer.IsProjectEvaluationFailure(exception);
+
+        Assert.True(result);
+    }
+
+    [Fact]
     public void ToId_WhenProjectNameContainsSeparators_ShouldNormalizeName()
     {
         var result = SolutionGraphAnalyzer.ToId(Path.Combine("src", "Company.Project-Api.csproj"));
@@ -256,6 +315,25 @@ public class SolutionGraphAnalyzerAnalyzeTests
 """);
 
         return projectPath;
+    }
+
+    private static string WriteLegacySolution(string root, params string[] projects)
+    {
+        var solution = Path.Combine(root, "sample.sln");
+        var projectEntries = string.Join(
+            Environment.NewLine,
+            projects.Select(project =>
+                $"Project(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"{Path.GetFileNameWithoutExtension(project)}\", \"{Path.GetRelativePath(root, project)}\", \"{{{Guid.NewGuid()}}}\"{Environment.NewLine}EndProject"));
+
+        File.WriteAllText(solution, $"""
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+{projectEntries}
+Global
+EndGlobal
+""");
+
+        return solution;
     }
 
     private static string WriteSolution(string root, params string[] projects)


### PR DESCRIPTION
### Motivation
- Project graph evaluation via MSBuild can fail (for example `InvalidProjectFileException` caused by Windows path-length limits), which aborts diagram generation instead of producing a best-effort result.
- Provide a robust fallback that can recover dependency information without requiring full MSBuild project evaluation.

### Description
- Catch project evaluation failures (including aggregate `InvalidProjectFileException`) and fall back from `Analyze` to a new `AnalyzeSolutionFile` path that parses `.slnx` and `.sln` content directly instead of using `ProjectGraph`.
- Introduce `AnalyzeProjectGraph`, `AnalyzeSolutionFile`, `AddDirectDependencies`, `GetSolutionProjectPaths`, `GetSlnxProjectPaths`, `GetSlnProjectPaths`, `GetDirectProjectReferencePaths(string)`, `GetProjectPath`, `GetAttributeValue`, and `IsProjectEvaluationFailure` to consolidate dependency construction logic for both code paths in `src/SlnxMermaid.Core/Graph/SolutionGraphAnalyzer.cs`.
- Preserve existing behavior for the normal `ProjectGraph` path while avoiding touching generated/cache files that cause long-path evaluation errors by parsing solution and project XML directly as a fallback.
- Add unit tests to `tests/SlnxMermaid.UnitTests/Graph/SolutionGraphAnalyzer.AnalyzeTests.cs` covering `AnalyzeSolutionFile` for `.slnx` and legacy `.sln` files and detection of `AggregateException` containing `InvalidProjectFileException`.

### Testing
- `git diff --check` passed with no whitespace issues.
- `dotnet test` could not be run in this environment because the `dotnet` SDK is not installed, so the new unit tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef02e3104832499c681295b00e1ae)