### PR TITLE
Configurable Mermaid node coloring: palettes, semantic roles, and mappings

### DIFF
--- a/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
+++ b/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
@@ -40,7 +40,7 @@ public sealed class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
 
         var emitter = new MermaidEmitter(naming, filter);
 
-        var mermaid = emitter.Emit(nodes, config.Diagram);
+        var mermaid = emitter.Emit(nodes, config.Diagram, config.Ui);
 
         await HandleResult(config.Output.File, mermaid, AnsiConsole.MarkupLine, cancellationToken);
 

--- a/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
+++ b/src/SlnxMermaid.CLI/Commands/GenerateCommand.cs
@@ -40,7 +40,7 @@ public sealed class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
 
         var emitter = new MermaidEmitter(naming, filter);
 
-        var mermaid = emitter.Emit(nodes, config.Diagram, config.Ui);
+        var mermaid = emitter.Emit(nodes, config);
 
         await HandleResult(config.Output.File, mermaid, AnsiConsole.MarkupLine, cancellationToken);
 

--- a/src/SlnxMermaid.Core/Config/SlnxMermaidConfig.cs
+++ b/src/SlnxMermaid.Core/Config/SlnxMermaidConfig.cs
@@ -11,5 +11,7 @@ public sealed class SlnxMermaidConfig
     public NamingConfig Naming { get; set; } = new NamingConfig();
 
     public OutputConfig Output { get; set; } = new OutputConfig();
+
+    public UiConfig Ui { get; set; } = new UiConfig();
 }
 }

--- a/src/SlnxMermaid.Core/Config/UiConfig.cs
+++ b/src/SlnxMermaid.Core/Config/UiConfig.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace SlnxMermaid.Core.Config
+{
+public sealed class UiConfig
+{
+    public string Mode { get; set; } = "dark";
+
+    public Dictionary<string, string> Semantic { get; set; } = new Dictionary<string, string>();
+
+    public Dictionary<string, object> Mappings { get; set; } = new Dictionary<string, object>();
+}
+}

--- a/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using SlnxMermaid.Core.Config;
 using SlnxMermaid.Core.Filtering;
 using SlnxMermaid.Core.Graph;
@@ -26,15 +27,24 @@ public sealed class MermaidEmitter
         IEnumerable<ProjectNode> nodes,
         DiagramConfig diagram)
     {
+        return Emit(nodes, diagram, null);
+    }
+
+    public string Emit(
+        IEnumerable<ProjectNode> nodes,
+        DiagramConfig diagram,
+        UiConfig ui)
+    {
         if (diagram == null)
             throw new ArgumentNullException(nameof(diagram));
 
+        var nodeList = nodes == null ? new List<ProjectNode>() : nodes.ToList();
         var sb = new StringBuilder();
         sb.AppendLine($"graph {diagram.Direction}");
 
         if (diagram.OrderDependenciesByDepth)
         {
-            var orderedEdges = OrderEdgesByDependencyDepth(nodes).ToList();
+            var orderedEdges = OrderEdgesByDependencyDepth(nodeList).ToList();
 
             if (orderedEdges.Count > 0)
                 sb.AppendLine();
@@ -49,11 +59,82 @@ public sealed class MermaidEmitter
         }
         else
         {
-            foreach (var edge in GetLegacySortedEdges(nodes))
+            foreach (var edge in GetLegacySortedEdges(nodeList))
                 sb.AppendLine($"    {edge.From} --> {edge.To}");
         }
 
+        if (ui != null)
+            AppendNodeStyles(sb, nodeList, ui);
+
         return sb.ToString();
+    }
+
+    private void AppendNodeStyles(StringBuilder sb, IEnumerable<ProjectNode> nodes, UiConfig ui)
+    {
+        var visibleNodes = nodes
+            .Where(node => _filter.IsAllowed(node.Id))
+            .OrderBy(node => _naming.Transform(node.Id), StringComparer.Ordinal)
+            .ToList();
+
+        if (visibleNodes.Count == 0)
+            return;
+
+        var resolver = new MermaidNodeStyleResolver(ui);
+        var classNamesByStyle = new Dictionary<MermaidNodeStyle, string>();
+        var classDefinitions = new List<KeyValuePair<string, MermaidNodeStyle>>();
+        var usedClassNames = new HashSet<string>(StringComparer.Ordinal);
+        var assignments = new List<KeyValuePair<string, string>>();
+
+        foreach (var node in visibleNodes)
+        {
+            var resolved = resolver.Resolve(node.Id);
+            string className;
+            if (!classNamesByStyle.TryGetValue(resolved.Style, out className))
+            {
+                className = CreateClassName(resolved);
+                var originalClassName = className;
+                var suffix = 2;
+                while (usedClassNames.Contains(className))
+                {
+                    className = originalClassName + "_" + suffix;
+                    suffix++;
+                }
+
+                usedClassNames.Add(className);
+                classNamesByStyle[resolved.Style] = className;
+                classDefinitions.Add(new KeyValuePair<string, MermaidNodeStyle>(className, resolved.Style));
+            }
+
+            assignments.Add(new KeyValuePair<string, string>(_naming.Transform(node.Id), className));
+        }
+
+        sb.AppendLine();
+
+        foreach (var definition in classDefinitions)
+        {
+            var style = definition.Value;
+            sb.AppendLine($"    classDef {definition.Key} fill:{style.Fill},stroke:{style.Stroke},color:{style.Color}");
+        }
+
+        sb.AppendLine();
+
+        foreach (var assignment in assignments)
+            sb.AppendLine($"    class {assignment.Key} {assignment.Value}");
+    }
+
+    private static string CreateClassName(MermaidNodeResolvedStyle resolved)
+    {
+        var baseName = string.IsNullOrWhiteSpace(resolved.BaseName) ? "style" : SanitizeClassToken(resolved.BaseName);
+        if (!resolved.Custom)
+            return "cls_" + baseName;
+
+        return "cls_" + baseName + "_custom_" + resolved.Style.Fill.TrimStart('#').ToLowerInvariant();
+    }
+
+    private static string SanitizeClassToken(string value)
+    {
+        var sanitized = Regex.Replace(value.ToLowerInvariant(), "[^a-z0-9_]+", "_").Trim('_');
+        return string.IsNullOrEmpty(sanitized) ? "style" : sanitized;
     }
 
     private IEnumerable<LegacyEdge> GetLegacySortedEdges(IEnumerable<ProjectNode> nodes)

--- a/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
@@ -25,12 +25,22 @@ public sealed class MermaidEmitter
 
     public string Emit(
         IEnumerable<ProjectNode> nodes,
+        SlnxMermaidConfig config)
+    {
+        if (config == null)
+            throw new ArgumentNullException(nameof(config));
+
+        return Emit(nodes, config.Diagram, config.Ui);
+    }
+
+    public string Emit(
+        IEnumerable<ProjectNode> nodes,
         DiagramConfig diagram)
     {
         return Emit(nodes, diagram, null);
     }
 
-    public string Emit(
+    private string Emit(
         IEnumerable<ProjectNode> nodes,
         DiagramConfig diagram,
         UiConfig ui)

--- a/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
@@ -30,29 +30,14 @@ public sealed class MermaidEmitter
         if (config == null)
             throw new ArgumentNullException(nameof(config));
 
-        return Emit(nodes, config.Diagram, config.Ui);
-    }
-
-    public string Emit(
-        IEnumerable<ProjectNode> nodes,
-        DiagramConfig diagram)
-    {
-        return Emit(nodes, diagram, null);
-    }
-
-    private string Emit(
-        IEnumerable<ProjectNode> nodes,
-        DiagramConfig diagram,
-        UiConfig ui)
-    {
-        if (diagram == null)
-            throw new ArgumentNullException(nameof(diagram));
+        if (config.Diagram == null)
+            throw new ArgumentNullException(nameof(config.Diagram));
 
         var nodeList = nodes == null ? new List<ProjectNode>() : nodes.ToList();
         var sb = new StringBuilder();
-        sb.AppendLine($"graph {diagram.Direction}");
+        sb.AppendLine($"graph {config.Diagram.Direction}");
 
-        if (diagram.OrderDependenciesByDepth)
+        if (config.Diagram.OrderDependenciesByDepth)
         {
             var orderedEdges = OrderEdgesByDependencyDepth(nodeList).ToList();
 
@@ -73,10 +58,24 @@ public sealed class MermaidEmitter
                 sb.AppendLine($"    {edge.From} --> {edge.To}");
         }
 
-        if (ui != null)
-            AppendNodeStyles(sb, nodeList, ui);
+        if (config.Ui != null)
+            AppendNodeStyles(sb, nodeList, config.Ui);
 
         return sb.ToString();
+    }
+
+    public string Emit(
+        IEnumerable<ProjectNode> nodes,
+        DiagramConfig diagram)
+    {
+        if (diagram == null)
+            throw new ArgumentNullException(nameof(diagram));
+
+        return Emit(nodes, new SlnxMermaidConfig
+        {
+            Diagram = diagram,
+            Ui = null
+        });
     }
 
     private void AppendNodeStyles(StringBuilder sb, IEnumerable<ProjectNode> nodes, UiConfig ui)

--- a/src/SlnxMermaid.Core/Emit/MermaidNodeStyle.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidNodeStyle.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace SlnxMermaid.Core.Emit
+{
+public sealed class MermaidNodeStyle : IEquatable<MermaidNodeStyle>
+{
+    public MermaidNodeStyle(string fill, string stroke, string color)
+    {
+        Fill = fill;
+        Stroke = stroke;
+        Color = color;
+    }
+
+    public string Fill { get; private set; }
+
+    public string Stroke { get; private set; }
+
+    public string Color { get; private set; }
+
+    public bool Equals(MermaidNodeStyle other)
+    {
+        if (other == null)
+            return false;
+
+        return string.Equals(Fill, other.Fill, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Stroke, other.Stroke, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Color, other.Color, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as MermaidNodeStyle);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Fill ?? string.Empty);
+            hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Stroke ?? string.Empty);
+            hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Color ?? string.Empty);
+            return hash;
+        }
+    }
+
+    public MermaidNodeStyle With(string fill, string stroke, string color)
+    {
+        return new MermaidNodeStyle(fill ?? Fill, stroke ?? Stroke, color ?? Color);
+    }
+}
+}

--- a/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using SlnxMermaid.Core.Config;
+
+namespace SlnxMermaid.Core.Emit
+{
+public sealed class MermaidNodeStyleResolver
+{
+    private static readonly Regex HexRegex = new Regex("^#[0-9a-fA-F]{6}$", RegexOptions.Compiled);
+    private static readonly string[] FallbackColorOrder = { "blue", "green", "yellow", "orange", "pink", "purple", "gray", "red" };
+
+    private readonly UiConfig _ui;
+    private readonly MermaidPalette _palette;
+    private readonly Dictionary<string, string> _semantic;
+
+    public MermaidNodeStyleResolver(UiConfig ui)
+    {
+        _ui = ui ?? new UiConfig();
+        _palette = MermaidPalette.ForMode(_ui.Mode);
+        _semantic = BuildSemanticMap(_ui.Semantic);
+        ValidateSemanticColors();
+        ValidateMappings();
+    }
+
+    public MermaidNodeResolvedStyle Resolve(string projectName)
+    {
+        var role = DetectRole(projectName);
+        var baseColorName = role != null ? _semantic[role] : null;
+        var baseStyle = baseColorName != null ? _palette.Get(baseColorName) : ResolveFallback(projectName);
+
+        object mappingValue;
+        string mappingKey;
+        if (TryGetExactMapping(projectName, out mappingKey, out mappingValue) || TryGetWildcardMapping(projectName, out mappingKey, out mappingValue))
+            return ApplyMapping(mappingValue, baseColorName != null ? baseStyle : null, baseColorName, projectName);
+
+        if (baseColorName != null)
+            return new MermaidNodeResolvedStyle(baseStyle, baseColorName, false);
+
+        return new MermaidNodeResolvedStyle(baseStyle, FallbackColorName(projectName), false);
+    }
+
+    private MermaidNodeResolvedStyle ApplyMapping(object value, MermaidNodeStyle baseStyle, string baseColorName, string projectName)
+    {
+        var text = value as string;
+        if (text != null)
+        {
+            text = text.Trim();
+            if (LooksLikeHex(text) && !IsHex(text))
+                throw new InvalidOperationException("Invalid hex value '" + text + "'. Expected #RRGGBB.");
+
+            if (IsHex(text))
+            {
+                var style = baseStyle != null
+                    ? baseStyle.With(NormalizeHex(text), null, null)
+                    : AutoStyle(NormalizeHex(text));
+                return new MermaidNodeResolvedStyle(style, baseColorName, true);
+            }
+
+            MermaidNodeStyle paletteStyle;
+            if (!_palette.TryGet(text, out paletteStyle))
+                throw new InvalidOperationException("Unknown palette color name '" + text + "'.");
+
+            return new MermaidNodeResolvedStyle(paletteStyle, text.ToLowerInvariant(), false);
+        }
+
+        var values = ToStringObjectDictionary(value);
+        if (values == null)
+            throw new InvalidOperationException("Invalid mapping value type for project '" + projectName + "'. Use a palette name, hex value, or style object.");
+
+        string fill = null;
+        string stroke = null;
+        string color = null;
+
+        foreach (var entry in values)
+        {
+            var field = entry.Key;
+            if (!string.Equals(field, "fill", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(field, "stroke", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(field, "color", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Invalid or unsupported style field '" + field + "'. Allowed fields are fill, stroke, and color.");
+
+            var fieldValue = entry.Value as string;
+            if (fieldValue == null || !IsHex(fieldValue.Trim()))
+                throw new InvalidOperationException("Invalid hex value for style field '" + field + "'. Expected #RRGGBB.");
+
+            if (string.Equals(field, "fill", StringComparison.OrdinalIgnoreCase))
+                fill = NormalizeHex(fieldValue);
+            else if (string.Equals(field, "stroke", StringComparison.OrdinalIgnoreCase))
+                stroke = NormalizeHex(fieldValue);
+            else
+                color = NormalizeHex(fieldValue);
+        }
+
+        var resolvedBase = baseStyle ?? (fill != null ? AutoStyle(fill) : ResolveFallback(projectName));
+        var resolved = resolvedBase.With(fill, stroke, color);
+        return new MermaidNodeResolvedStyle(resolved, baseColorName ?? FallbackColorName(projectName), fill != null || stroke != null || color != null);
+    }
+
+    private static Dictionary<string, string> BuildSemanticMap(Dictionary<string, string> configured)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "presentation", "blue" },
+            { "application", "green" },
+            { "domain", "yellow" },
+            { "infrastructure", "orange" },
+            { "dataaccess", "pink" },
+            { "tooling", "purple" },
+            { "tests", "gray" }
+        };
+
+        if (configured != null)
+        {
+            foreach (var entry in configured)
+                result[entry.Key] = entry.Value;
+        }
+
+        return result;
+    }
+
+    private void ValidateSemanticColors()
+    {
+        foreach (var entry in _semantic)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Value) || !_palette.TryGet(entry.Value, out _))
+                throw new InvalidOperationException("Unknown palette color name '" + entry.Value + "' for semantic role '" + entry.Key + "'.");
+        }
+    }
+
+    private void ValidateMappings()
+    {
+        if (_ui.Mappings == null)
+            return;
+
+        foreach (var entry in _ui.Mappings)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key))
+                throw new InvalidOperationException("Mapping keys cannot be empty.");
+
+            ValidateMappingValue(entry.Key, entry.Value);
+        }
+    }
+
+    private void ValidateMappingValue(string key, object value)
+    {
+        var text = value as string;
+        if (text != null)
+        {
+            text = text.Trim();
+            if (LooksLikeHex(text) && !IsHex(text))
+                throw new InvalidOperationException("Invalid hex value '" + text + "' for mapping '" + key + "'. Expected #RRGGBB.");
+
+            if (IsHex(text))
+                return;
+
+            if (!_palette.TryGet(text, out _))
+                throw new InvalidOperationException("Unknown palette color name '" + text + "' for mapping '" + key + "'.");
+
+            return;
+        }
+
+        var values = ToStringObjectDictionary(value);
+        if (values == null)
+            throw new InvalidOperationException("Invalid mapping value type for mapping '" + key + "'. Use a palette name, hex value, or style object.");
+
+        foreach (var entry in values)
+        {
+            if (!string.Equals(entry.Key, "fill", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(entry.Key, "stroke", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(entry.Key, "color", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Invalid or unsupported style field '" + entry.Key + "'. Allowed fields are fill, stroke, and color.");
+
+            var fieldValue = entry.Value as string;
+            if (fieldValue == null || !IsHex(fieldValue.Trim()))
+                throw new InvalidOperationException("Invalid hex value for style field '" + entry.Key + "' in mapping '" + key + "'. Expected #RRGGBB.");
+        }
+    }
+
+    private bool TryGetExactMapping(string projectName, out string key, out object value)
+    {
+        key = null;
+        value = null;
+        if (_ui.Mappings == null)
+            return false;
+
+        foreach (var entry in _ui.Mappings)
+        {
+            if (entry.Key.IndexOf('*') >= 0)
+                continue;
+
+            if (string.Equals(entry.Key, projectName, StringComparison.OrdinalIgnoreCase))
+            {
+                key = entry.Key;
+                value = entry.Value;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetWildcardMapping(string projectName, out string key, out object value)
+    {
+        key = null;
+        value = null;
+        if (_ui.Mappings == null)
+            return false;
+
+        var match = _ui.Mappings
+            .Where(entry => entry.Key.IndexOf('*') >= 0 && WildcardMatches(entry.Key, projectName))
+            .OrderByDescending(entry => Specificity(entry.Key))
+            .ThenBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+
+        if (match.Key == null)
+            return false;
+
+        key = match.Key;
+        value = match.Value;
+        return true;
+    }
+
+    private string DetectRole(string projectName)
+    {
+        var roles = new List<KeyValuePair<string, string[]>>
+        {
+            new KeyValuePair<string, string[]>("tests", new[] { "Tests", "Test", "Spec", "Specs" }),
+            new KeyValuePair<string, string[]>("presentation", new[] { "Api", "Web", "MinimalApi", "Host", "Gateway" }),
+            new KeyValuePair<string, string[]>("application", new[] { "Application" }),
+            new KeyValuePair<string, string[]>("domain", new[] { "Domain", "Core" }),
+            new KeyValuePair<string, string[]>("infrastructure", new[] { "Infrastructure" }),
+            new KeyValuePair<string, string[]>("dataaccess", new[] { "DataAccess", "Persistence", "Database", "Storage" }),
+            new KeyValuePair<string, string[]>("tooling", new[] { "Seeder", "Migrator", "Tools", "Tool", "CLI", "Console" })
+        };
+
+        var segments = SplitSegments(projectName);
+        foreach (var role in roles)
+        {
+            if (role.Value.Any(term => segments.Any(segment => string.Equals(segment, term, StringComparison.OrdinalIgnoreCase))))
+                return role.Key;
+        }
+
+        foreach (var role in roles)
+        {
+            if (role.Value.Any(term => projectName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0))
+                return role.Key;
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> SplitSegments(string projectName)
+    {
+        return projectName.Split(new[] { '.', '-', '_', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private MermaidNodeStyle ResolveFallback(string projectName)
+    {
+        return _palette.Get(FallbackColorName(projectName));
+    }
+
+    private string FallbackColorName(string projectName)
+    {
+        var hash = StableHash(projectName ?? string.Empty);
+        return FallbackColorOrder[hash % FallbackColorOrder.Length];
+    }
+
+    private static int StableHash(string value)
+    {
+        unchecked
+        {
+            var hash = 2166136261u;
+            foreach (var ch in value.ToUpperInvariant())
+            {
+                hash ^= ch;
+                hash *= 16777619;
+            }
+
+            return (int)(hash & 0x7fffffff);
+        }
+    }
+
+    private static bool WildcardMatches(string pattern, string value)
+    {
+        var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+        return Regex.IsMatch(value, regex, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    private static int Specificity(string pattern)
+    {
+        return pattern.Count(ch => ch != '*');
+    }
+
+    private static bool LooksLikeHex(string value)
+    {
+        return value != null && value.StartsWith("#", StringComparison.Ordinal);
+    }
+
+    private static bool IsHex(string value)
+    {
+        return value != null && HexRegex.IsMatch(value);
+    }
+
+    private static string NormalizeHex(string value)
+    {
+        return value.Trim().ToUpperInvariant();
+    }
+
+    private static Dictionary<string, object> ToStringObjectDictionary(object value)
+    {
+        var typed = value as Dictionary<string, object>;
+        if (typed != null)
+            return typed;
+
+        var dictionary = value as IDictionary;
+        if (dictionary == null)
+            return null;
+
+        var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in dictionary)
+            result[Convert.ToString(entry.Key, CultureInfo.InvariantCulture)] = entry.Value;
+
+        return result;
+    }
+
+    private static MermaidNodeStyle AutoStyle(string fill)
+    {
+        var readable = IsLight(fill) ? "#000000" : "#FFFFFF";
+        var stroke = readable;
+        return new MermaidNodeStyle(fill, stroke, readable);
+    }
+
+    private static bool IsLight(string hex)
+    {
+        var r = int.Parse(hex.Substring(1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        var g = int.Parse(hex.Substring(3, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        var b = int.Parse(hex.Substring(5, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        var luminance = (0.299 * r) + (0.587 * g) + (0.114 * b);
+        return luminance > 186;
+    }
+}
+
+public sealed class MermaidNodeResolvedStyle
+{
+    public MermaidNodeResolvedStyle(MermaidNodeStyle style, string baseName, bool custom)
+    {
+        Style = style;
+        BaseName = baseName;
+        Custom = custom;
+    }
+
+    public MermaidNodeStyle Style { get; private set; }
+
+    public string BaseName { get; private set; }
+
+    public bool Custom { get; private set; }
+}
+}

--- a/src/SlnxMermaid.Core/Emit/MermaidPalette.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidPalette.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SlnxMermaid.Core.Emit
+{
+public sealed class MermaidPalette
+{
+    private readonly Dictionary<string, MermaidNodeStyle> _styles;
+
+    private MermaidPalette(Dictionary<string, MermaidNodeStyle> styles)
+    {
+        _styles = styles;
+    }
+
+    public static MermaidPalette DarkModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
+    {
+        { "blue", new MermaidNodeStyle("#1565C0", "#90CAF9", "#FFFFFF") },
+        { "green", new MermaidNodeStyle("#2E7D32", "#A5D6A7", "#FFFFFF") },
+        { "yellow", new MermaidNodeStyle("#F9A825", "#FFF59D", "#000000") },
+        { "orange", new MermaidNodeStyle("#EF6C00", "#FFCC80", "#FFFFFF") },
+        { "pink", new MermaidNodeStyle("#AD1457", "#F48FB1", "#FFFFFF") },
+        { "purple", new MermaidNodeStyle("#6A1B9A", "#CE93D8", "#FFFFFF") },
+        { "gray", new MermaidNodeStyle("#37474F", "#B0BEC5", "#FFFFFF") },
+        { "red", new MermaidNodeStyle("#B71C1C", "#EF9A9A", "#FFFFFF") }
+    });
+
+    public static MermaidPalette LightModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
+    {
+        { "blue", new MermaidNodeStyle("#E3F2FD", "#1976D2", "#000000") },
+        { "green", new MermaidNodeStyle("#E8F5E9", "#388E3C", "#000000") },
+        { "yellow", new MermaidNodeStyle("#FFFDE7", "#FBC02D", "#000000") },
+        { "orange", new MermaidNodeStyle("#FFF3E0", "#F57C00", "#000000") },
+        { "pink", new MermaidNodeStyle("#FCE4EC", "#C2185B", "#000000") },
+        { "purple", new MermaidNodeStyle("#F3E5F5", "#7B1FA2", "#000000") },
+        { "gray", new MermaidNodeStyle("#ECEFF1", "#607D8B", "#000000") },
+        { "red", new MermaidNodeStyle("#FFEBEE", "#D32F2F", "#000000") }
+    });
+
+    public IEnumerable<string> Names
+    {
+        get { return _styles.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase); }
+    }
+
+    public bool TryGet(string name, out MermaidNodeStyle style)
+    {
+        return _styles.TryGetValue(name, out style);
+    }
+
+    public MermaidNodeStyle Get(string name)
+    {
+        MermaidNodeStyle style;
+        if (!TryGet(name, out style))
+            throw new InvalidOperationException("Unknown palette color name '" + name + "'.");
+
+        return style;
+    }
+
+    public static MermaidPalette ForMode(string mode)
+    {
+        var normalizedMode = string.IsNullOrWhiteSpace(mode) ? "dark" : mode.Trim();
+
+        if (string.Equals(normalizedMode, "dark", StringComparison.OrdinalIgnoreCase))
+            return DarkModePalette;
+
+        if (string.Equals(normalizedMode, "light", StringComparison.OrdinalIgnoreCase))
+            return LightModePalette;
+
+        throw new InvalidOperationException("Unknown ui.mode '" + mode + "'. Supported values are 'dark' and 'light'.");
+    }
+}
+}

--- a/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
+++ b/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
@@ -65,7 +65,7 @@ namespace SlnxMermaidVsix
             await outputService.LogAsync(pane,
                 Strings.LogEmittingMermaid);
 
-            var mermaid = emitter.Emit(nodes, config.Diagram);
+            var mermaid = emitter.Emit(nodes, config.Diagram, config.Ui);
             var markdownDiagram = mermaid.WrapCodeForMarkdown();
 
             if (string.IsNullOrWhiteSpace(config.Output?.File))

--- a/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
+++ b/src/SlnxMermaidVsix/Services/MermaidDiagramGenerator.cs
@@ -65,7 +65,7 @@ namespace SlnxMermaidVsix
             await outputService.LogAsync(pane,
                 Strings.LogEmittingMermaid);
 
-            var mermaid = emitter.Emit(nodes, config.Diagram, config.Ui);
+            var mermaid = emitter.Emit(nodes, config);
             var markdownDiagram = mermaid.WrapCodeForMarkdown();
 
             if (string.IsNullOrWhiteSpace(config.Output?.File))

--- a/tests/SlnxMermaid.UnitTests/Config/ConfigDefaultsTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/ConfigDefaultsTests.cs
@@ -13,6 +13,7 @@ public class ConfigDefaultsTests
         Assert.NotNull(config.Filters);
         Assert.NotNull(config.Naming);
         Assert.NotNull(config.Output);
+        Assert.NotNull(config.Ui);
     }
 
     [Fact]
@@ -54,6 +55,14 @@ public class ConfigDefaultsTests
 
         Assert.Empty(config.Aliases);
         Assert.Null(config.StripPrefix);
+    }
+
+    [Fact]
+    public void UiConfig_DefaultMode_ShouldBeDark()
+    {
+        var config = new UiConfig();
+
+        Assert.Equal("dark", config.Mode);
     }
 
     [Fact]

--- a/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
@@ -21,6 +21,22 @@ public class YamlConfigLoaderLoadTests
         Assert.Equal("S", result.Naming.Aliases["Sample"]);
     }
 
+
+    [Fact]
+    public void Load_WhenUiConfigExists_ShouldDeserializeSemanticAndMappings()
+    {
+        var path = GetConfigPath("ui-config.yml");
+
+        var result = YamlConfigLoader.Load(path);
+
+        Assert.Equal("light", result.Ui.Mode);
+        Assert.Equal("red", result.Ui.Semantic["application"]);
+        Assert.Equal("blue", result.Ui.Mappings["MinimalApi"]);
+        Assert.Equal("gray", result.Ui.Mappings["*Model*"]);
+        Assert.NotNull(result.Ui.Mappings["Application"]);
+        Assert.NotNull(result.Ui.Mappings["Infrastructure"]);
+    }
+
     [Fact]
     public void Load_WhenIncludeTransitiveDependenciesIsMissing_ShouldUseDefaultFalse()
     {

--- a/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
@@ -1,0 +1,247 @@
+using SlnxMermaid.Core.Config;
+using SlnxMermaid.Core.Emit;
+using SlnxMermaid.Core.Filtering;
+using SlnxMermaid.Core.Graph;
+using SlnxMermaid.Core.Naming;
+
+namespace SlnxMermaid.UnitTests.Emit;
+
+public class MermaidEmitterUiStyleTests
+{
+    [Fact]
+    public void Emit_WithUiAndMissingMode_ShouldUseDefaultDarkMode()
+    {
+        var result = Emit([Node("MinimalApi")], new UiConfig { Mode = null! });
+
+        Assert.Contains("classDef cls_blue fill:#1565C0,stroke:#90CAF9,color:#FFFFFF", result);
+        Assert.Contains("class MinimalApi cls_blue", result);
+    }
+
+    [Fact]
+    public void Emit_WithLightMode_ShouldUseLightPalette()
+    {
+        var result = Emit([Node("MinimalApi")], new UiConfig { Mode = "light" });
+
+        Assert.Contains("classDef cls_blue fill:#E3F2FD,stroke:#1976D2,color:#000000", result);
+    }
+
+    [Fact]
+    public void Emit_WhenSemanticIsMissing_ShouldUseSemanticDefaults()
+    {
+        var result = Emit([Node("Application")], new UiConfig());
+
+        Assert.Contains("classDef cls_green fill:#2E7D32,stroke:#A5D6A7,color:#FFFFFF", result);
+        Assert.Contains("class Application cls_green", result);
+    }
+
+    [Fact]
+    public void Emit_WhenExactMappingOverrideExists_ShouldUseMappedPaletteColor()
+    {
+        var ui = new UiConfig { Mappings = { ["MinimalApi"] = "red" } };
+
+        var result = Emit([Node("MinimalApi")], ui);
+
+        Assert.Contains("classDef cls_red fill:#B71C1C,stroke:#EF9A9A,color:#FFFFFF", result);
+        Assert.Contains("class MinimalApi cls_red", result);
+    }
+
+    [Fact]
+    public void Emit_WhenWildcardMappingOverrideExists_ShouldUseMostSpecificWildcardMapping()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["*Model*"] = "gray",
+                ["*UserModel"] = "purple"
+            }
+        };
+
+        var result = Emit([Node("UserModel")], ui);
+
+        Assert.Contains("classDef cls_purple fill:#6A1B9A,stroke:#CE93D8,color:#FFFFFF", result);
+        Assert.Contains("class UserModel cls_purple", result);
+    }
+
+    [Fact]
+    public void Emit_WhenExactAndWildcardMappingsMatch_ShouldPreferExactMapping()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["*Model*"] = "gray",
+                ["UserModel"] = "red"
+            }
+        };
+
+        var result = Emit([Node("UserModel")], ui);
+
+        Assert.Contains("classDef cls_red fill:#B71C1C,stroke:#EF9A9A,color:#FFFFFF", result);
+        Assert.Contains("class UserModel cls_red", result);
+    }
+
+    [Fact]
+    public void Emit_WhenPartialStyleObjectExists_ShouldMergeMissingFieldsFromSemanticBaseStyle()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["Application"] = new Dictionary<string, object> { ["fill"] = "#141414" }
+            }
+        };
+
+        var result = Emit([Node("Application")], ui);
+
+        Assert.Contains("classDef cls_green_custom_141414 fill:#141414,stroke:#A5D6A7,color:#FFFFFF", result);
+    }
+
+    [Fact]
+    public void Emit_WhenFullStyleObjectExists_ShouldUseFullCustomStyle()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["Infrastructure"] = new Dictionary<string, object>
+                {
+                    ["fill"] = "#EF6C00",
+                    ["stroke"] = "#FFCC80",
+                    ["color"] = "#FFFFFF"
+                }
+            }
+        };
+
+        var result = Emit([Node("Infrastructure")], ui);
+
+        Assert.Contains("classDef cls_orange_custom_ef6c00 fill:#EF6C00,stroke:#FFCC80,color:#FFFFFF", result);
+    }
+
+    [Fact]
+    public void Emit_WhenRawHexMappingExists_ShouldUseFillAndSemanticBaseStrokeAndColor()
+    {
+        var ui = new UiConfig { Mappings = { ["Application"] = "#141414" } };
+
+        var result = Emit([Node("Application")], ui);
+
+        Assert.Contains("classDef cls_green_custom_141414 fill:#141414,stroke:#A5D6A7,color:#FFFFFF", result);
+    }
+
+    [Fact]
+    public void Emit_WhenModeIsUnknown_ShouldThrowClearError()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => Emit([Node("Application")], new UiConfig { Mode = "sepia" }));
+
+        Assert.Contains("Unknown ui.mode", ex.Message);
+    }
+
+    [Fact]
+    public void Emit_WhenPaletteColorIsUnknown_ShouldThrowClearError()
+    {
+        var ui = new UiConfig { Mappings = { ["Application"] = "teal" } };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Emit([Node("Application")], ui));
+
+        Assert.Contains("Unknown palette color name", ex.Message);
+    }
+
+    [Fact]
+    public void Emit_WhenHexIsInvalid_ShouldThrowClearError()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["Application"] = new Dictionary<string, object> { ["fill"] = "141414" }
+            }
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Emit([Node("Application")], ui));
+
+        Assert.Contains("Invalid hex value", ex.Message);
+    }
+
+
+    [Fact]
+    public void Emit_WhenMappingKeyIsEmpty_ShouldThrowClearError()
+    {
+        var ui = new UiConfig { Mappings = { [""] = "blue" } };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Emit([Node("Application")], ui));
+
+        Assert.Contains("Mapping keys cannot be empty", ex.Message);
+    }
+
+    [Fact]
+    public void Emit_WhenStyleFieldIsUnsupported_ShouldThrowClearError()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["Application"] = new Dictionary<string, object> { ["border"] = "#141414" }
+            }
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Emit([Node("Application")], ui));
+
+        Assert.Contains("Invalid or unsupported style field", ex.Message);
+    }
+
+    [Fact]
+    public void Emit_WhenMappingValueTypeIsUnsupported_ShouldThrowClearError()
+    {
+        var ui = new UiConfig { Mappings = { ["Application"] = 42 } };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Emit([Node("Application")], ui));
+
+        Assert.Contains("Invalid mapping value type", ex.Message);
+    }
+
+    [Fact]
+    public void Emit_WhenNoMappingOrSemanticRoleMatches_ShouldUseDeterministicFallbackColor()
+    {
+        var first = Emit([Node("Billing")], new UiConfig());
+        var second = Emit([Node("Billing")], new UiConfig());
+
+        Assert.Equal(first, second);
+        Assert.Contains("class Billing cls_", first);
+    }
+
+    [Fact]
+    public void Emit_WithUi_ShouldEmitClassDefinitionsOnceAndAssignEveryNodeAfterDefinitions()
+    {
+        var app = Node("Application");
+        var appAlias = Node("MyApp.Application");
+        app.Dependencies.Add(appAlias);
+
+        var result = Emit([app, appAlias], new UiConfig());
+
+        Assert.Equal(1, CountOccurrences(result, "classDef cls_green "));
+        Assert.Contains("class Application cls_green", result);
+        Assert.Contains("class MyApp.Application cls_green", result);
+        Assert.True(result.IndexOf("classDef", StringComparison.Ordinal) < result.IndexOf("class Application", StringComparison.Ordinal));
+    }
+
+    private static string Emit(IEnumerable<ProjectNode> nodes, UiConfig ui) =>
+        CreateEmitter().Emit(nodes, new DiagramConfig { Direction = "TD", OrderDependenciesByDepth = false }, ui);
+
+    private static ProjectNode Node(string id) => new(id, id + ".csproj");
+
+    private static MermaidEmitter CreateEmitter() =>
+        new(new NameTransformer(new NamingConfig()), new ProjectFilter([]));
+
+    private static int CountOccurrences(string value, string find)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(find, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += find.Length;
+        }
+
+        return count;
+    }
+}

--- a/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
@@ -225,7 +225,11 @@ public class MermaidEmitterUiStyleTests
     }
 
     private static string Emit(IEnumerable<ProjectNode> nodes, UiConfig ui) =>
-        CreateEmitter().Emit(nodes, new DiagramConfig { Direction = "TD", OrderDependenciesByDepth = false }, ui);
+        CreateEmitter().Emit(nodes, new SlnxMermaidConfig
+        {
+            Diagram = new DiagramConfig { Direction = "TD", OrderDependenciesByDepth = false },
+            Ui = ui
+        });
 
     private static ProjectNode Node(string id) => new(id, id + ".csproj");
 

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/ui-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/ui-config.yml
@@ -1,0 +1,14 @@
+solution: ./src/sample.slnx
+ui:
+  mode: light
+  semantic:
+    application: red
+  mappings:
+    MinimalApi: blue
+    "*Model*": gray
+    Application:
+      fill: "#141414"
+    Infrastructure:
+      fill: "#EF6C00"
+      stroke: "#FFCC80"
+      color: "#FFFFFF"


### PR DESCRIPTION
### Motivation
- Provide deterministic, theme-aware node coloring for Mermaid diagrams using built-in dark/light palettes, semantic role defaults, and optional YAML overrides.
- Allow project-specific style overrides (exact, wildcard, partial/full object, or raw hex) while keeping deterministic fallbacks and clear validation errors.
- Reuse identical styles across nodes to emit a single `classDef` per unique style and assign nodes to classes after edges.

### Description
- Added `UiConfig` and wired it into `SlnxMermaidConfig` so YAML can define `ui.mode`, `ui.semantic`, and `ui.mappings` with `dark` as the default mode.  
- Introduced `MermaidPalette`, `MermaidNodeStyle`, and `MermaidNodeStyleResolver` implementing dark/light palettes, semantic defaults, exact/wildcard mapping resolution (with specificity and deterministic tie-break), partial/full mapping merge behavior, raw-hex handling with readable stroke/text fallback, and stable hash-based fallbacks.  
- Extended `MermaidEmitter.Emit` to accept an optional `UiConfig`, append unique `classDef` declarations once after edges, and then emit class assignments for all visible nodes using deterministic, Mermaid-safe class names.  
- Added unit tests and YAML test data covering palette modes, semantic defaults, exact/wildcard priority, partial/full/raw mapping behavior, validation errors, deterministic fallback behavior, and YAML deserialization of the UI config.

### Testing
- Ran `git diff --check` to validate workspace changes and found no whitespace or diff errors.  
- Attempted to run the test suite with `dotnet test SlnxMermaid.slnx`, but the environment does not have the `dotnet` SDK installed so unit tests were not executed here.  
- Added focused unit tests under `tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs` and a YAML fixture `tests/.../ui-config.yml` which can be executed in CI or a local environment with the .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2e998fc48324ab7ba27304b21e75)