### PR TITLE
Fix Mermaid UI style assignment expectation

### DIFF
--- a/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
@@ -220,7 +220,7 @@ public class MermaidEmitterUiStyleTests
 
         Assert.Equal(1, CountOccurrences(result, "classDef cls_green "));
         Assert.Contains("class Application cls_green", result);
-        Assert.Contains("class MyApp.Application cls_green", result);
+        Assert.Contains("class MyApp_Application cls_green", result);
         Assert.True(result.IndexOf("classDef", StringComparison.Ordinal) < result.IndexOf("class Application", StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
### Motivation
- The UI style emitter test failed because project names with dots are transformed to allowed Mermaid identifiers (dots replaced with underscores), so the test expectation needed to match the emitter output.

### Description
- Update assertion in `tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs` to expect `MyApp_Application` instead of `MyApp.Application` for the emitted Mermaid class assignment.

### Testing
- Ran `git diff --check` which passed, and attempted `dotnet test` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3ee48d6083249152d2a8f300b219)