### PR TITLE
Expand VSIX starter config and make ui.mappings case-sensitive

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,10 +37,11 @@ ui:
     dataAccess: pink        # DataAccess/Persistence/Database/Storage projects
     tooling: purple         # CLI/Console/Tools/Seeder/Migrator projects
     tests: gray             # Tests/Test/Spec projects
-  # Optional per-project overrides. Keys may be exact project names or wildcard patterns.
+  # Optional per-project overrides. Keys may be exact project names or wildcard patterns. Matching is case-sensitive.
   mappings:
     SlnxMermaid.CLI: purple
     "*Tests*": gray
+    "*App*": yellow
     SlnxMermaid.Core:
       fill: "#141414"
       stroke: "#90CAF9"
@@ -99,7 +100,7 @@ Supported palette colors are `blue`, `green`, `yellow`, `orange`, `pink`, `purpl
 | `tests` | `Tests`, `Test`, `Spec`, `Specs` | `gray` |
 
 ### `ui.mappings`
-Defines per-project color overrides. Mapping keys may be exact project names or wildcard patterns with `*`. Exact project names win over wildcard matches; if several wildcard patterns match, the most specific pattern wins.
+Defines per-project color overrides. Mapping keys may be exact project names or wildcard patterns with `*`. Matching is case-sensitive, so `*App*` matches `MyApp.Api` but not `myapp.api`. Exact project names win over wildcard matches; if several wildcard patterns match, the most specific pattern wins.
 
 Mapping values can be:
 

--- a/docs/vsix.md
+++ b/docs/vsix.md
@@ -25,7 +25,7 @@ From an opened solution (`.sln` / `.slnx`), the extension triggers diagram gener
 
 ## Configuration behavior
 
-The extension uses the same project configuration approach as the CLI workflow (solution + output + filters + naming) so teams can keep one architecture standard regardless of entry point.
+The extension uses the same project configuration approach as the CLI workflow (solution, diagram, filters, UI colors, naming, and output) so teams can keep one architecture standard regardless of entry point. If `slnx-mermaid.yml` is missing in the solution directory, the first VSIX run creates a complete starter configuration with sample values.
 
 ## VSIX packaging note
 

--- a/docs/vsix/GETTING_STARTED.md
+++ b/docs/vsix/GETTING_STARTED.md
@@ -33,7 +33,7 @@ It helps visualize project dependencies and architecture directly inside Visual 
 ## Configuration
 
 The extension uses the same `slnx-mermaid.yml` configuration model as the CLI.
-You can keep one shared config in the solution directory (output path, filters, naming).
+You can keep one shared config in the solution directory (solution path, diagram settings, filters, UI colors, naming, and output path). If the file is missing, the first VSIX run creates a complete starter configuration with sample values.
 
 ## Output
 

--- a/slnx-mermaid.yml
+++ b/slnx-mermaid.yml
@@ -28,10 +28,11 @@ ui:
     dataAccess: pink        # DataAccess/Persistence/Database/Storage projects
     tooling: purple         # CLI/Console/Tools/Seeder/Migrator projects
     tests: gray             # Tests/Test/Spec projects
-  # Optional per-project overrides. Keys may be exact project names or wildcard patterns.
+  # Optional per-project overrides. Keys may be exact project names or wildcard patterns. Matching is case-sensitive.
   mappings:
     SlnxMermaid.CLI: purple
     "*Tests*": gray
+    "*App*": yellow
     SlnxMermaid.Core:
       fill: "#141414"
       stroke: "#90CAF9"

--- a/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
@@ -192,7 +192,7 @@ public sealed class MermaidNodeStyleResolver
             if (entry.Key.IndexOf('*') >= 0)
                 continue;
 
-            if (string.Equals(entry.Key, projectName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(entry.Key, projectName, StringComparison.Ordinal))
             {
                 key = entry.Key;
                 value = entry.Value;
@@ -213,7 +213,7 @@ public sealed class MermaidNodeStyleResolver
         var match = _ui.Mappings
             .Where(entry => entry.Key.IndexOf('*') >= 0 && WildcardMatches(entry.Key, projectName))
             .OrderByDescending(entry => Specificity(entry.Key))
-            .ThenBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(entry => entry.Key, StringComparer.Ordinal)
             .FirstOrDefault();
 
         if (match.Key == null)
@@ -287,7 +287,7 @@ public sealed class MermaidNodeStyleResolver
     private static bool WildcardMatches(string pattern, string value)
     {
         var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
-        return Regex.IsMatch(value, regex, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        return Regex.IsMatch(value, regex, RegexOptions.CultureInvariant);
     }
 
     private static int Specificity(string pattern)

--- a/src/SlnxMermaidVsix/Services/MermaidConfigBootstrapper.cs
+++ b/src/SlnxMermaidVsix/Services/MermaidConfigBootstrapper.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using SlnxMermaid.Core.Config;
 using SlnxMermaid.Core.Extensions;
@@ -82,16 +82,11 @@ namespace SlnxMermaidVsix
             return new SlnxMermaidConfig
             {
                 Solution = Path.GetFileName(solutionPath),
-                Output = new OutputConfig
+                Diagram = new DiagramConfig
                 {
-                    File = Strings.DefaultOutputFile
-                },
-                Naming = new NamingConfig
-                {
-                    StripPrefix = string.IsNullOrEmpty(normalizedSolutionName)
-                        ? string.Empty
-                        : $"{normalizedSolutionName}_",
-                    Aliases = new Dictionary<string, string>()
+                    Direction = "TD",
+                    IncludeTransitiveDependencies = false,
+                    OrderDependenciesByDepth = true
                 },
                 Filters = new FilterConfig
                 {
@@ -112,6 +107,46 @@ namespace SlnxMermaidVsix
                         Strings.ExcludeServiceDefaults,
                         Strings.ExcludeDto
                     }.ToList()
+                },
+                Ui = new UiConfig
+                {
+                    Mode = "dark",
+                    Semantic = new Dictionary<string, string>
+                    {
+                        ["presentation"] = "blue",
+                        ["application"] = "green",
+                        ["domain"] = "yellow",
+                        ["infrastructure"] = "orange",
+                        ["dataAccess"] = "pink",
+                        ["tooling"] = "purple",
+                        ["tests"] = "gray"
+                    },
+                    Mappings = new Dictionary<string, object>
+                    {
+                        ["Sample.CLI"] = "purple",
+                        ["*App*"] = "yellow",
+                        ["Sample.Core"] = new Dictionary<string, string>
+                        {
+                            ["fill"] = "#141414",
+                            ["stroke"] = "#90CAF9",
+                            ["color"] = "#FFFFFF"
+                        }
+                    }
+                },
+                Naming = new NamingConfig
+                {
+                    StripPrefix = string.IsNullOrEmpty(normalizedSolutionName)
+                        ? string.Empty
+                        : $"{normalizedSolutionName}_",
+                    Aliases = new Dictionary<string, string>
+                    {
+                        ["Core"] = "CORE",
+                        ["CLI"] = "CommandLineInterface"
+                    }
+                },
+                Output = new OutputConfig
+                {
+                    File = Strings.DefaultOutputFile
                 },
             };
         }

--- a/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
@@ -64,6 +64,55 @@ public class MermaidEmitterUiStyleTests
     }
 
     [Fact]
+    public void Emit_WhenWildcardMappingMatchesCaseSensitiveProjectName_ShouldUseMappedPaletteColor()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["*App*"] = "yellow"
+            }
+        };
+
+        var result = Emit([Node("MyApp.Api")], ui);
+
+        Assert.Contains("classDef cls_yellow fill:#F9A825,stroke:#FFF59D,color:#000000", result);
+        Assert.Contains("class MyApp_Api cls_yellow", result);
+    }
+
+    [Fact]
+    public void Emit_WhenWildcardMappingDiffersByCase_ShouldNotMatch()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["*App*"] = "yellow"
+            }
+        };
+
+        var result = Emit([Node("sample.application")], ui);
+
+        Assert.DoesNotContain("classDef cls_yellow fill:#F9A825,stroke:#FFF59D,color:#000000", result);
+    }
+
+    [Fact]
+    public void Emit_WhenExactMappingDiffersByCase_ShouldNotMatch()
+    {
+        var ui = new UiConfig
+        {
+            Mappings =
+            {
+                ["MinimalApi"] = "red"
+            }
+        };
+
+        var result = Emit([Node("minimalapi")], ui);
+
+        Assert.DoesNotContain("classDef cls_red fill:#B71C1C,stroke:#EF9A9A,color:#FFFFFF", result);
+    }
+
+    [Fact]
     public void Emit_WhenExactAndWildcardMappingsMatch_ShouldPreferExactMapping()
     {
         var ui = new UiConfig


### PR DESCRIPTION
### Motivation
- Provide a full, usable starter `slnx-mermaid.yml` when the VSIX runs the first time so teams get all supported options pre-filled (diagram, filters, UI, mappings, naming, output). 
- Support wildcard project-name mappings (e.g. `*App*`) in the default example so users can try per-project overrides out of the box. 
- Honor the requested case-sensitive matching for `ui.mappings` so exact names and wildcard patterns respect case.

### Description
- Populate the VSIX bootstrap config in `CreateDefaultConfig` with full sections: `Diagram` (direction, includeTransitiveDependencies, orderDependenciesByDepth), `Filters`, `Ui` (mode, `Semantic` defaults and `Mappings` sample including `"*App*": "yellow"`), `Naming` (stripPrefix and sample `Aliases`) and `Output` (`File`). (`src/SlnxMermaidVsix/Services/MermaidConfigBootstrapper.cs`)
- Make `ui.mappings` lookups case-sensitive by switching exact-match comparison to `StringComparison.Ordinal`, making wildcard matching use case-sensitive regex (removed `IgnoreCase`), and tie-breaker ordering to `StringComparer.Ordinal`. (`src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs`)
- Update documentation and example `slnx-mermaid.yml` to show the `*App*` sample and to state that mapping matching is case-sensitive. (`docs/configuration.md`, `slnx-mermaid.yml`, `docs/vsix.md`, `docs/vsix/GETTING_STARTED.md`)
- Add unit tests covering case-sensitive mapping behavior: `Emit_WhenWildcardMappingMatchesCaseSensitiveProjectName_ShouldUseMappedPaletteColor`, `Emit_WhenWildcardMappingDiffersByCase_ShouldNotMatch`, and `Emit_WhenExactMappingDiffersByCase_ShouldNotMatch`. (`tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs`)

### Testing
- Ran `git diff --check` to validate whitespace and basic diffs, which passed. 
- Added unit tests for case-sensitive mapping behavior but did not run them in CI locally because `dotnet` is not available in the environment (`dotnet test` was not executed). 
- The change was committed as `Expand VSIX config template and case-sensitive color mappings` and includes the updated docs, sample config, resolver logic, and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20742268d883249ba160b5dd981fb4)