### PR TITLE
Add YAML config loader edge case tests

### DIFF
--- a/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
@@ -1,4 +1,7 @@
-﻿using SlnxMermaid.Core.Config;
+using System.Collections;
+using SlnxMermaid.Core.Config;
+using SlnxMermaid.Core.Exceptions;
+using YamlDotNet.Core;
 
 namespace SlnxMermaid.UnitTests.Config;
 
@@ -21,6 +24,47 @@ public class YamlConfigLoaderLoadTests
         Assert.Equal("S", result.Naming.Aliases["Sample"]);
     }
 
+    [Fact]
+    public void Load_WhenAllSupportedValuesExist_ShouldDeserializeEverySection()
+    {
+        var path = GetConfigPath("all-values-config.yml");
+
+        var result = YamlConfigLoader.Load(path);
+
+        Assert.Equal("../solutions/Company.Sample.slnx", result.Solution);
+        Assert.Equal("../docs/architecture/{date}-sample.md", result.Output.File);
+        Assert.Equal("BT", result.Diagram.Direction);
+        Assert.True(result.Diagram.IncludeTransitiveDependencies);
+        Assert.False(result.Diagram.OrderDependenciesByDepth);
+        Assert.Equal(new[]
+        {
+            "*.Tests",
+            "Company.Legacy.*",
+            "Project With Spaces",
+            "Project-With-Dashes",
+            "Project_With_Underscores"
+        }, result.Filters.Exclude);
+        Assert.Equal("Company.Sample.", result.Naming.StripPrefix);
+        Assert.Equal("API", result.Naming.Aliases["Company.Sample.Api"]);
+        Assert.Equal("App Layer", result.Naming.Aliases["Company.Sample.Application"]);
+        Assert.Equal("Infra", result.Naming.Aliases["Company.Sample.Infrastructure"]);
+        Assert.Equal("light", result.Ui.Mode);
+        Assert.Equal("blue", result.Ui.Semantic["presentation"]);
+        Assert.Equal("green", result.Ui.Semantic["application"]);
+        Assert.Equal("yellow", result.Ui.Semantic["domain"]);
+        Assert.Equal("orange", result.Ui.Semantic["infrastructure"]);
+        Assert.Equal("pink", result.Ui.Semantic["dataAccess"]);
+        Assert.Equal("purple", result.Ui.Semantic["tooling"]);
+        Assert.Equal("gray", result.Ui.Semantic["tests"]);
+        Assert.Equal("purple", result.Ui.Mappings["Company.Sample.Api"]);
+        Assert.Equal("gray", result.Ui.Mappings["*.Tests"]);
+        Assert.Equal("green", result.Ui.Mappings["*Application*"]);
+        Assert.Equal("#112233", result.Ui.Mappings["Company.Sample.Domain"]);
+        var infrastructureStyle = Assert.IsAssignableFrom<IDictionary>(result.Ui.Mappings["Company.Sample.Infrastructure"]);
+        Assert.Equal("#141414", infrastructureStyle["fill"]);
+        Assert.Equal("#90CAF9", infrastructureStyle["stroke"]);
+        Assert.Equal("#FFFFFF", infrastructureStyle["color"]);
+    }
 
     [Fact]
     public void Load_WhenUiConfigExists_ShouldDeserializeSemanticAndMappings()
@@ -49,11 +93,271 @@ public class YamlConfigLoaderLoadTests
     }
 
     [Fact]
+    public void Load_WhenOnlySolutionExists_ShouldKeepDefaultNestedConfigs()
+    {
+        var result = LoadFromText("solution: ./minimal.slnx");
+
+        Assert.Equal("./minimal.slnx", result.Solution);
+        Assert.Equal("TD", result.Diagram.Direction);
+        Assert.False(result.Diagram.IncludeTransitiveDependencies);
+        Assert.True(result.Diagram.OrderDependenciesByDepth);
+        Assert.Empty(result.Filters.Exclude);
+        Assert.Null(result.Naming.StripPrefix);
+        Assert.Empty(result.Naming.Aliases);
+        Assert.Null(result.Output.File);
+        Assert.Equal("dark", result.Ui.Mode);
+        Assert.Empty(result.Ui.Semantic);
+        Assert.Empty(result.Ui.Mappings);
+    }
+
+    [Fact]
+    public void Load_WhenSectionsAreEmptyMappings_ShouldKeepSectionDefaults()
+    {
+        var path = GetConfigPath("empty-sections-config.yml");
+
+        var result = YamlConfigLoader.Load(path);
+
+        Assert.Equal("./src/sample.slnx", result.Solution);
+        Assert.NotNull(result.Diagram);
+        Assert.Equal("TD", result.Diagram.Direction);
+        Assert.False(result.Diagram.IncludeTransitiveDependencies);
+        Assert.True(result.Diagram.OrderDependenciesByDepth);
+        Assert.NotNull(result.Filters);
+        Assert.Empty(result.Filters.Exclude);
+        Assert.NotNull(result.Naming);
+        Assert.Null(result.Naming.StripPrefix);
+        Assert.Empty(result.Naming.Aliases);
+        Assert.NotNull(result.Output);
+        Assert.Null(result.Output.File);
+        Assert.NotNull(result.Ui);
+        Assert.Equal("dark", result.Ui.Mode);
+        Assert.Empty(result.Ui.Semantic);
+        Assert.Empty(result.Ui.Mappings);
+    }
+
+    [Fact]
+    public void Load_WhenOptionalSectionsAreExplicitNull_ShouldKeepNullSectionsForLaterValidation()
+    {
+        var result = LoadFromText("""
+            solution: ./sample.slnx
+            diagram: null
+            filters: null
+            naming: null
+            output: null
+            ui: null
+            """);
+
+        Assert.Equal("./sample.slnx", result.Solution);
+        Assert.Null(result.Diagram);
+        Assert.Null(result.Filters);
+        Assert.Null(result.Naming);
+        Assert.Null(result.Output);
+        Assert.Null(result.Ui);
+    }
+
+    [Fact]
+    public void Load_WhenCollectionValuesAreExplicitNull_ShouldKeepNullCollectionsForLaterValidation()
+    {
+        var result = LoadFromText("""
+            solution: ./sample.slnx
+            filters:
+              exclude: null
+            naming:
+              aliases: null
+            ui:
+              semantic: null
+              mappings: null
+            """);
+
+        Assert.Equal("./sample.slnx", result.Solution);
+        Assert.Null(result.Filters.Exclude);
+        Assert.Null(result.Naming.Aliases);
+        Assert.Null(result.Ui.Semantic);
+        Assert.Null(result.Ui.Mappings);
+    }
+
+    [Theory]
+    [InlineData("TD")]
+    [InlineData("TB")]
+    [InlineData("BT")]
+    [InlineData("LR")]
+    [InlineData("RL")]
+    [InlineData("lR")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Load_WhenDiagramDirectionHasAnyStringValue_ShouldPreserveValue(string direction)
+    {
+        var result = LoadFromText($$"""
+            solution: ./sample.slnx
+            diagram:
+              direction: "{{direction}}"
+            """);
+
+        Assert.Equal(direction, result.Diagram.Direction);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Load_WhenDiagramBooleanMixChanges_ShouldDeserializeCombination(bool includeTransitiveDependencies, bool orderDependenciesByDepth)
+    {
+        var result = LoadFromText($$"""
+            solution: ./sample.slnx
+            diagram:
+              includeTransitiveDependencies: {{includeTransitiveDependencies.ToString().ToLowerInvariant()}}
+              orderDependenciesByDepth: {{orderDependenciesByDepth.ToString().ToLowerInvariant()}}
+            """);
+
+        Assert.Equal(includeTransitiveDependencies, result.Diagram.IncludeTransitiveDependencies);
+        Assert.Equal(orderDependenciesByDepth, result.Diagram.OrderDependenciesByDepth);
+    }
+
+    [Theory]
+    [InlineData("dark")]
+    [InlineData("light")]
+    [InlineData("DaRk")]
+    [InlineData("LIGHT")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Load_WhenUiModeHasAnyStringValue_ShouldPreserveValue(string mode)
+    {
+        var result = LoadFromText($$"""
+            solution: ./sample.slnx
+            ui:
+              mode: "{{mode}}"
+            """);
+
+        Assert.Equal(mode, result.Ui.Mode);
+    }
+
+    [Theory]
+    [InlineData("blue")]
+    [InlineData("green")]
+    [InlineData("yellow")]
+    [InlineData("orange")]
+    [InlineData("pink")]
+    [InlineData("purple")]
+    [InlineData("gray")]
+    [InlineData("red")]
+    [InlineData("GrEeN")]
+    [InlineData("unknown-user-value")]
+    public void Load_WhenSemanticColorHasAnyStringValue_ShouldPreserveValueForLaterValidation(string color)
+    {
+        var result = LoadFromText($$"""
+            solution: ./sample.slnx
+            ui:
+              semantic:
+                application: "{{color}}"
+            """);
+
+        Assert.Equal(color, result.Ui.Semantic["application"]);
+    }
+
+    [Fact]
+    public void Load_WhenYamlHasMixedCaseStringsAndSpecialCharacters_ShouldPreserveStringsAndDeserializeBooleans()
+    {
+        var path = GetConfigPath("edge-case-config.yml");
+
+        var result = YamlConfigLoader.Load(path);
+
+        Assert.Equal("./Ścieżka Z Odstępami/Sample Solution.slnx", result.Solution);
+        Assert.Equal("./out/Diagram Final {date}.md", result.Output.File);
+        Assert.Equal("lR", result.Diagram.Direction);
+        Assert.True(result.Diagram.IncludeTransitiveDependencies);
+        Assert.False(result.Diagram.OrderDependenciesByDepth);
+        Assert.Empty(result.Filters.Exclude);
+        Assert.Equal("  Company.  ", result.Naming.StripPrefix);
+        Assert.Equal("Alias With Spaces", result.Naming.Aliases["Project With Spaces"]);
+        Assert.Equal("mIxEd Alias 123", result.Naming.Aliases["UPPER.case-Mix_123"]);
+        Assert.Equal("DaRk", result.Ui.Mode);
+        Assert.Equal("GrEeN", result.Ui.Semantic["application"]);
+        Assert.Equal("#aBc123", result.Ui.Mappings["Project With Spaces"]);
+        Assert.Equal("PuRpLe", result.Ui.Mappings["*case-Mix*"]);
+        var objectStyle = Assert.IsAssignableFrom<IDictionary>(result.Ui.Mappings["ObjectStyle"]);
+        Assert.Equal("#abcdef", objectStyle["FILL"]);
+        Assert.Equal("#123456", objectStyle["Stroke"]);
+        Assert.Equal("#FEDCBA", objectStyle["color"]);
+    }
+
+    [Fact]
+    public void Load_WhenYamlHasDuplicateKeys_ShouldLetLastValueWin()
+    {
+        var path = GetConfigPath("duplicate-keys-config.yml");
+
+        var result = YamlConfigLoader.Load(path);
+
+        Assert.Equal("./second.slnx", result.Solution);
+        Assert.Equal("./second.md", result.Output.File);
+        Assert.Equal("RL", result.Diagram.Direction);
+        Assert.True(result.Diagram.IncludeTransitiveDependencies);
+        Assert.False(result.Diagram.OrderDependenciesByDepth);
+        Assert.Equal(new[] { "Second" }, result.Filters.Exclude);
+        Assert.Equal("Second.", result.Naming.StripPrefix);
+        Assert.Equal("SecondAlias", result.Naming.Aliases["Duplicate"]);
+        Assert.Equal("light", result.Ui.Mode);
+        Assert.Equal("red", result.Ui.Semantic["application"]);
+        Assert.Equal("orange", result.Ui.Mappings["Duplicate.Project"]);
+    }
+
+    [Fact]
+    public void Load_WhenUnknownPropertiesExist_ShouldIgnoreThem()
+    {
+        var path = GetConfigPath("unknown-properties-config.yml");
+
+        var result = YamlConfigLoader.Load(path);
+
+        Assert.Equal("./src/sample.slnx", result.Solution);
+        Assert.Equal("LR", result.Diagram.Direction);
+        Assert.Equal(new[] { "Tests" }, result.Filters.Exclude);
+        Assert.Equal("Company.", result.Naming.StripPrefix);
+        Assert.Equal("./out/diagram.md", result.Output.File);
+        Assert.Equal("dark", result.Ui.Mode);
+    }
+
+    [Theory]
+    [InlineData("empty-config.yml")]
+    [InlineData("comments-only-config.yml")]
+    public void Load_WhenYamlDocumentHasNoValues_ShouldThrowYamlDeserializeException(string fileName)
+    {
+        var path = GetConfigPath(fileName);
+
+        var exception = Assert.Throws<YamlDeserializeException>(() => YamlConfigLoader.Load(path));
+
+        Assert.Equal(path, exception.FilePath);
+        Assert.Contains(path, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_WhenYamlIsMalformed_ShouldThrowYamlException()
+    {
+        var exception = Assert.Throws<YamlException>(() => LoadFromText("solution: [unterminated"));
+
+        Assert.False(string.IsNullOrWhiteSpace(exception.Message));
+    }
+
+    [Fact]
     public void Load_WhenFileDoesNotExist_ShouldThrowFileNotFoundException()
     {
         var path = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid()}.yml");
 
         Assert.Throws<FileNotFoundException>(() => YamlConfigLoader.Load(path));
+    }
+
+    private static SlnxMermaidConfig LoadFromText(string yaml)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"slnx-mermaid-test-{Guid.NewGuid()}.yml");
+        File.WriteAllText(path, yaml);
+
+        try
+        {
+            return YamlConfigLoader.Load(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     private static string GetConfigPath(string fileName) =>

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/all-values-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/all-values-config.yml
@@ -1,0 +1,39 @@
+solution: ../solutions/Company.Sample.slnx
+output:
+  file: ../docs/architecture/{date}-sample.md
+diagram:
+  direction: BT
+  includeTransitiveDependencies: true
+  orderDependenciesByDepth: false
+filters:
+  exclude:
+    - "*.Tests"
+    - "Company.Legacy.*"
+    - "Project With Spaces"
+    - "Project-With-Dashes"
+    - "Project_With_Underscores"
+naming:
+  stripPrefix: Company.Sample.
+  aliases:
+    Company.Sample.Api: API
+    Company.Sample.Application: App Layer
+    Company.Sample.Infrastructure: Infra
+ui:
+  mode: light
+  semantic:
+    presentation: blue
+    application: green
+    domain: yellow
+    infrastructure: orange
+    dataAccess: pink
+    tooling: purple
+    tests: gray
+  mappings:
+    Company.Sample.Api: purple
+    "*.Tests": gray
+    "*Application*": green
+    Company.Sample.Domain: "#112233"
+    Company.Sample.Infrastructure:
+      fill: "#141414"
+      stroke: "#90CAF9"
+      color: "#FFFFFF"

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/comments-only-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/comments-only-config.yml
@@ -1,0 +1,2 @@
+# The loader should treat a comments-only YAML document the same as an empty one.
+# This catches accidental successful deserialization of a document without values.

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/duplicate-keys-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/duplicate-keys-config.yml
@@ -1,0 +1,32 @@
+solution: ./first.slnx
+solution: ./second.slnx
+output:
+  file: ./first.md
+  file: ./second.md
+diagram:
+  direction: TD
+  direction: RL
+  includeTransitiveDependencies: false
+  includeTransitiveDependencies: true
+  orderDependenciesByDepth: true
+  orderDependenciesByDepth: false
+filters:
+  exclude:
+    - First
+  exclude:
+    - Second
+naming:
+  stripPrefix: First.
+  stripPrefix: Second.
+  aliases:
+    Duplicate: FirstAlias
+    Duplicate: SecondAlias
+ui:
+  mode: dark
+  mode: light
+  semantic:
+    application: green
+    application: red
+  mappings:
+    Duplicate.Project: blue
+    Duplicate.Project: orange

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/edge-case-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/edge-case-config.yml
@@ -1,0 +1,25 @@
+solution: "./Ścieżka Z Odstępami/Sample Solution.slnx"
+output:
+  file: "./out/Diagram Final {date}.md"
+diagram:
+  direction: "lR"
+  includeTransitiveDependencies: TRUE
+  orderDependenciesByDepth: FaLsE
+filters:
+  exclude: []
+naming:
+  stripPrefix: "  Company.  "
+  aliases:
+    "Project With Spaces": "Alias With Spaces"
+    "UPPER.case-Mix_123": "mIxEd Alias 123"
+ui:
+  mode: "DaRk"
+  semantic:
+    application: "GrEeN"
+  mappings:
+    "Project With Spaces": "#aBc123"
+    "*case-Mix*": "PuRpLe"
+    "ObjectStyle":
+      FILL: "#abcdef"
+      Stroke: "#123456"
+      color: "#FEDCBA"

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/empty-sections-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/empty-sections-config.yml
@@ -1,0 +1,6 @@
+solution: ./src/sample.slnx
+diagram: {}
+filters: {}
+naming: {}
+output: {}
+ui: {}

--- a/tests/SlnxMermaid.UnitTests/TestData/Config/unknown-properties-config.yml
+++ b/tests/SlnxMermaid.UnitTests/TestData/Config/unknown-properties-config.yml
@@ -1,0 +1,19 @@
+solution: ./src/sample.slnx
+unknownRootValue: should-be-ignored
+diagram:
+  direction: LR
+  unsupportedNestedValue: should-also-be-ignored
+filters:
+  exclude:
+    - Tests
+  unsupportedNestedList:
+    - ignored
+naming:
+  stripPrefix: Company.
+  unsupportedNestedValue: ignored
+output:
+  file: ./out/diagram.md
+  unsupportedNestedValue: ignored
+ui:
+  mode: dark
+  unsupportedNestedValue: ignored


### PR DESCRIPTION
### Motivation
- Improve robustness of YAML config handling by exercising many real-world and pathological inputs so deserialization and later validation behave predictably. 
- Cover empty documents, comments-only docs, duplicate keys, mixed-case/Unicode strings, explicit `null` sections/collections, unknown properties, boolean combinations, and malformed YAML. 

### Description
- Expanded `tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs` with numerous test cases that exercise full-config deserialization, defaults, empty/`null` sections, collection `null`s, duplicate-key behavior (last-wins), mixed-case strings and Unicode, and malformed YAML error handling. 
- Added test helper `LoadFromText(string yaml)` to write temporary YAML fixtures inline for fast variations without creating files. 
- Added test data YAML fixtures under `tests/SlnxMermaid.UnitTests/TestData/Config/` including `all-values-config.yml`, `edge-case-config.yml`, `duplicate-keys-config.yml`, `empty-config.yml`, `comments-only-config.yml`, `empty-sections-config.yml`, and `unknown-properties-config.yml`. 
- Included required test imports such as `System.Collections` and `YamlDotNet.Core` and assertions that map to `YamlDeserializeException` and `YamlException` behavior for edge cases. 

### Testing
- Attempted to run the unit test suite with `dotnet test tests/SlnxMermaid.UnitTests/SlnxMermaid.UnitTests.csproj --no-restore` but the `dotnet` SDK is not available in the environment so tests were not executed. 
- No automated test results were produced in this environment; added tests and fixtures should be runnable in a developer environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a1b7ae988324973e1438c2746e9c)