### PR TITLE
Align documentation with current generator behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ dotnet tool install --global slnx-mermaid
 slnx-mermaid --config slnx-mermaid.yml
 ```
 
+The CLI reads the configured `.sln` or `.slnx`, analyzes project references, and writes a Markdown file containing a fenced Mermaid graph to `output.file`. Relative `solution` and `output.file` paths are resolved from the configuration file location.
+
 ## Fast start (VSIX)
 
 1. Install the extension from Visual Studio Marketplace.
 2. Open a `.sln` / `.slnx` solution in Visual Studio.
 3. Right-click the solution node in Solution Explorer.
 4. Run the **SLNX Mermaid** command.
+5. If `slnx-mermaid.yml` is missing next to the solution, the extension creates a starter config before generation.
 
 ## License
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,7 @@ title: CLI Guide
 
 # CLI Guide
 
-The CLI endpoint is distributed as a .NET global tool.
+The CLI endpoint is distributed as a .NET global tool and runs the same generation pipeline used by the Visual Studio extension.
 
 ## Installation
 
@@ -13,23 +13,27 @@ The CLI endpoint is distributed as a .NET global tool.
 dotnet tool install --global slnx-mermaid
 ```
 
-Verify:
+Verify the tool is available:
 
 ```bash
-dotnet tool search slnx-mermaid
+slnx-mermaid --help
 ```
 
 ## Basic usage
+
+Run from a directory that contains `slnx-mermaid.yml`:
 
 ```bash
 slnx-mermaid
 ```
 
-or with an explicit config path:
+or provide an explicit config path:
 
 ```bash
 slnx-mermaid --config build/architecture.yml
 ```
+
+The command loads the YAML configuration, resolves relative paths from the configuration file location, analyzes project references in the configured solution, prints the generated Markdown-wrapped Mermaid diagram to the console, and writes the same Markdown to `output.file`.
 
 ## CLI options
 
@@ -44,14 +48,18 @@ slnx-mermaid --config build/architecture.yml
 Order of resolution:
 
 1. If `--config <path>` is provided, that file is used.
-2. Otherwise, current directory lookup for:
-   - `slnx-mermaid.yml`
-   - `slnx-mermaid.yaml`
+2. Otherwise, the CLI looks for `slnx-mermaid.yml` in the current working directory.
 
-If no config file is found, the process exits with an error.
+If no config file is found, the process exits with an error. The default lookup does **not** currently try `slnx-mermaid.yaml`; use `--config slnx-mermaid.yaml` if your file uses that extension.
 
 ## Typical CI flow
 
 1. Commit `slnx-mermaid.yml` to the repo.
-2. Run `slnx-mermaid` in pipeline.
-3. Commit generated diagrams or publish as build artifacts.
+2. Run `slnx-mermaid` from the repository root, or pass the config path explicitly.
+3. Commit generated diagrams or publish them as build artifacts.
+
+Example:
+
+```bash
+slnx-mermaid --config slnx-mermaid.yml
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,11 +13,13 @@ The CLI endpoint is distributed as a .NET global tool and runs the same generati
 dotnet tool install --global slnx-mermaid
 ```
 
-Verify the tool is available:
+Verify the tool is available and print the generated help text:
 
 ```bash
 slnx-mermaid --help
 ```
+
+`--help` is handled by Spectre.Console.Cli as a built-in help option for the configured default command.
 
 ## Basic usage
 
@@ -40,8 +42,7 @@ The command loads the YAML configuration, resolves relative paths from the confi
 | Option            | Description                           |
 | ----------------- | ------------------------------------- |
 | `--config <path>` | Path to a specific configuration file |
-| `--version`       | Show tool version                     |
-| `--help`          | Show help information                 |
+| `-h`, `--help`    | Show help information                 |
 
 ## Configuration file resolution
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ title: Configuration Reference
 
 # Configuration Reference
 
-SLNX Mermaid uses YAML configuration.
+SLNX Mermaid uses YAML configuration. The same model is used by the CLI and by the Visual Studio extension.
 
 ## Example
 
@@ -13,7 +13,7 @@ SLNX Mermaid uses YAML configuration.
 solution: SlnxMermaid.slnx
 
 diagram:
-  direction: TD   # TD (top-down) | LR (left-right)
+  direction: TD   # Passed to Mermaid graph direction; common values: TD, LR, BT, RL
   includeTransitiveDependencies: false  # false = direct only | true = direct + indirect
   orderDependenciesByDepth: true  # false = legacy alphabetical edge order | true = dependency-depth order
 
@@ -37,12 +37,13 @@ ui:
     dataAccess: pink        # DataAccess/Persistence/Database/Storage projects
     tooling: purple         # CLI/Console/Tools/Seeder/Migrator projects
     tests: gray             # Tests/Test/Spec projects
-  # Optional per-project overrides. Keys may be exact project names or wildcard patterns. Matching is case-sensitive.
+  # Optional per-project overrides. Keys use normalized project ids: project file names without extension,
+  # with dots and hyphens replaced by underscores. Wildcards use * and are case-sensitive.
   mappings:
-    SlnxMermaid.CLI: purple
+    SlnxMermaid_CLI: purple
     "*Tests*": gray
     "*App*": yellow
-    SlnxMermaid.Core:
+    SlnxMermaid_Core:
       fill: "#141414"
       stroke: "#90CAF9"
       color: "#FFFFFF"
@@ -51,7 +52,7 @@ naming:
   stripPrefix: SlnxMermaid_
   aliases:
     Core: CORE
-    CLI: Command Line Interface
+    CLI: CommandLineInterface
 
 output:
   file: docs/architecture/{date}-dependency-graph-mermaid.md
@@ -60,11 +61,18 @@ output:
 ## Sections
 
 ### `solution`
-Path to `.sln` / `.slnx` file.
+Path to a `.sln` or `.slnx` file.
+
+The generator first tries MSBuild project graph analysis. If project evaluation fails with an MSBuild project-file error, it falls back to parsing the solution file directly and reading project references from project XML.
+
+Supported project references in the fallback parser:
+
+- `.slnx`: `<Project Path="..." />` entries
+- `.sln`: `csproj`, `fsproj`, and `vbproj` project entries
+- project files: `ProjectReference` items
 
 ### `diagram.direction`
-- `TD` (top-down)
-- `LR` (left-right)
+Value emitted after Mermaid `graph`, for example `TD` or `LR`. The tool does not validate this field beyond passing the value through to Mermaid.
 
 ### `diagram.includeTransitiveDependencies`
 - `false` (default): include only direct project references.
@@ -76,7 +84,9 @@ Path to `.sln` / `.slnx` file.
 - `false`: preserve the legacy alphabetical Mermaid edge order.
 
 ### `filters.exclude`
-Project name patterns to omit from the graph.
+Case-insensitive substring filters applied to normalized project ids before edges and styles are emitted. These are not glob patterns: `Tests` excludes any normalized project id containing `tests`, while `*Tests*` would be treated as a literal substring containing asterisks.
+
+Normalized project ids are project file names without extension, with dots and hyphens replaced by underscores. For example, `SlnxMermaid.CLI.csproj` becomes `SlnxMermaid_CLI`.
 
 ### `ui.mode`
 Chooses the built-in diagram color palette. Supported values are:
@@ -85,7 +95,7 @@ Chooses the built-in diagram color palette. Supported values are:
 - `light`
 
 ### `ui.semantic`
-Overrides colors assigned automatically to semantic project roles detected from project names.
+Overrides colors assigned automatically to semantic project roles detected from normalized project ids.
 
 Supported palette colors are `blue`, `green`, `yellow`, `orange`, `pink`, `purple`, `gray`, and `red`. The built-in roles are:
 
@@ -99,8 +109,12 @@ Supported palette colors are `blue`, `green`, `yellow`, `orange`, `pink`, `purpl
 | `tooling` | `Seeder`, `Migrator`, `Tools`, `Tool`, `CLI`, `Console` | `purple` |
 | `tests` | `Tests`, `Test`, `Spec`, `Specs` | `gray` |
 
+Semantic role keys are case-insensitive. Color names are resolved in the active palette selected by `ui.mode`.
+
 ### `ui.mappings`
-Defines per-project color overrides. Mapping keys may be exact project names or wildcard patterns with `*`. Matching is case-sensitive, so `*App*` matches `MyApp.Api` but not `myapp.api`. Exact project names win over wildcard matches; if several wildcard patterns match, the most specific pattern wins.
+Defines per-project color overrides. Mapping keys use normalized project ids, not display names after `naming.stripPrefix` or `naming.aliases`.
+
+Keys may be exact ids or wildcard patterns with `*`. Matching is case-sensitive, so `*App*` matches `MyApp_Api` but not `myapp_api`. Exact ids win over wildcard matches; if several wildcard patterns match, the most specific pattern wins.
 
 Mapping values can be:
 
@@ -108,14 +122,20 @@ Mapping values can be:
 - a fill color in `#RRGGBB` format
 - a style object with `fill`, `stroke`, and/or `color` fields in `#RRGGBB` format
 
+If a single hex value is used, it is treated as the fill color. Text and stroke colors are chosen automatically unless the project has a semantic base style.
+
 ### `naming.stripPrefix`
-Removes repeated prefix from project names in diagram output.
+Removes a repeated prefix from normalized project ids in diagram output.
+
+Example: with `stripPrefix: SlnxMermaid_`, `SlnxMermaid_Core` is emitted as `Core`.
 
 ### `naming.aliases`
-Maps project names to documentation-friendly labels.
+Maps transformed output names to Mermaid node ids. Aliases are applied after project id normalization and after `stripPrefix`.
+
+Prefer Mermaid-safe aliases made of letters, digits, and underscores. The emitter writes aliases as node ids, not quoted labels, so spaces or punctuation can make the Mermaid output invalid.
 
 ### `output.file`
-Target output path for generated Mermaid markdown.
+Target output path for generated Mermaid markdown. The file contains a fenced Markdown code block with `mermaid` as the language.
 
 ## Placeholder support
 
@@ -127,7 +147,7 @@ Target output path for generated Mermaid markdown.
 
 Both `solution` and `output.file` support:
 
-- relative paths (resolved from config location)
+- relative paths (resolved from the configuration file location)
 - absolute paths
 
 Forward slashes are recommended for cross-platform compatibility.

--- a/docs/vsix.md
+++ b/docs/vsix.md
@@ -5,11 +5,11 @@ title: VSIX Guide
 
 # VSIX Guide (Visual Studio Extension)
 
-The VSIX endpoint lets you generate Mermaid diagrams directly from Visual Studio.
+The VSIX endpoint lets you generate Mermaid diagrams directly from Visual Studio. It uses the same core generator as the CLI.
 
 ## What it does
 
-From an opened solution (`.sln` / `.slnx`), the extension triggers diagram generation and writes Mermaid output, equivalent in purpose to the CLI endpoint.
+From an opened solution (`.sln` / `.slnx`), the extension creates or loads `slnx-mermaid.yml` in the solution directory, analyzes project references, writes the configured Markdown output file, and opens it in Visual Studio.
 
 ## Installation
 
@@ -21,11 +21,11 @@ From an opened solution (`.sln` / `.slnx`), the extension triggers diagram gener
 1. Open a solution in Visual Studio.
 2. In Solution Explorer, right-click the solution node.
 3. Run the **SLNX Mermaid** command.
-4. Open the generated Mermaid markdown file.
+4. The extension writes the configured Mermaid markdown file and opens it automatically.
 
 ## Configuration behavior
 
-The extension uses the same project configuration approach as the CLI workflow (solution, diagram, filters, UI colors, naming, and output) so teams can keep one architecture standard regardless of entry point. If `slnx-mermaid.yml` is missing in the solution directory, the first VSIX run creates a complete starter configuration with sample values.
+The extension uses the same project configuration approach as the CLI workflow (solution, diagram, filters, UI colors, naming, and output) so teams can keep one architecture standard regardless of entry point. It always looks for `slnx-mermaid.yml` next to the loaded solution. If that file is missing, the first VSIX run creates a complete starter configuration with sample values and opens it.
 
 ## VSIX packaging note
 

--- a/docs/vsix/GETTING_STARTED.md
+++ b/docs/vsix/GETTING_STARTED.md
@@ -7,11 +7,6 @@
 [![NuGet](https://img.shields.io/nuget/v/slnx-mermaid.svg)](https://www.nuget.org/packages/slnx-mermaid/)
 [![GitHub](https://img.shields.io/badge/GitHub-asienicki%2Fslnx--mermaid-181717?logo=github)](https://github.com/asienicki/slnx-mermaid)
 
-[![CI](https://github.com/asienicki/slnx-mermaid/actions/workflows/CI.yml/badge.svg)](https://github.com/asienicki/slnx-mermaid/actions/workflows/CI.yml)
-[![Code scanning alerts](https://img.shields.io/github/issues/asienicki/slnx-mermaid/code-scanning?label=Code%20scanning%20alerts)](https://github.com/asienicki/slnx-mermaid/security/code-scanning)
-[![NuGet](https://img.shields.io/nuget/v/slnx-mermaid.svg)](https://www.nuget.org/packages/slnx-mermaid/)
-[![GitHub](https://img.shields.io/badge/GitHub-asienicki%2Fslnx--mermaid-181717?logo=github)](https://github.com/asienicki/slnx-mermaid)
-
 ## Overview
 
 SLNX Mermaid generates Mermaid diagrams from Visual Studio solution files (`.sln` / `.slnx`).
@@ -27,21 +22,21 @@ It helps visualize project dependencies and architecture directly inside Visual 
 1. Open a solution (`.sln` or `.slnx`).
 2. Right-click the solution node in Solution Explorer.
 3. Select the **SLNX Mermaid** command.
-4. The diagram file will be generated.
-5. Open the generated file in a Mermaid-compatible viewer or Markdown preview.
+4. The extension generates the configured Markdown file and opens it automatically.
+5. Use Visual Studio Markdown preview or another Mermaid-compatible viewer to render the diagram.
 
 ## Configuration
 
 The extension uses the same `slnx-mermaid.yml` configuration model as the CLI.
-You can keep one shared config in the solution directory (solution path, diagram settings, filters, UI colors, naming, and output path). If the file is missing, the first VSIX run creates a complete starter configuration with sample values.
+You can keep one shared config in the solution directory (solution path, diagram settings, filters, UI colors, naming, and output path). The extension looks for `slnx-mermaid.yml` next to the loaded solution. If the file is missing, the first VSIX run creates a complete starter configuration with sample values and opens it.
 
 ## Output
 
 The extension generates a Mermaid diagram file describing:
 
-* Project references
-* Dependency relationships
-* Structural overview
+* Direct project references by default
+* Optional transitive project dependencies when enabled in configuration
+* Semantic or custom Mermaid node styling
 
 ## Troubleshooting
 

--- a/slnx-mermaid.yml
+++ b/slnx-mermaid.yml
@@ -28,12 +28,12 @@ ui:
     dataAccess: pink        # DataAccess/Persistence/Database/Storage projects
     tooling: purple         # CLI/Console/Tools/Seeder/Migrator projects
     tests: gray             # Tests/Test/Spec projects
-  # Optional per-project overrides. Keys may be exact project names or wildcard patterns. Matching is case-sensitive.
+  # Optional per-project overrides. Keys use normalized project ids (file name without extension, dots/hyphens as underscores). Wildcards are case-sensitive.
   mappings:
-    SlnxMermaid.CLI: purple
+    SlnxMermaid_CLI: purple
     "*Tests*": gray
     "*App*": yellow
-    SlnxMermaid.Core:
+    SlnxMermaid_Core:
       fill: "#141414"
       stroke: "#90CAF9"
       color: "#FFFFFF"


### PR DESCRIPTION
### Motivation

- Documentation and example config contained several mismatches with the actual generator and VSIX behavior, which caused confusion for users.
- The goal was to make docs and the sample `slnx-mermaid.yml` accurately describe how the CLI, config model and VSIX operate.
- Clarify semantics for normalized project ids, mapping keys, filter behavior, path resolution and fallback parsing so configs applied by the code are predictable.
- Remove duplicated or misleading content (badges / instructions) from VSIX getting-started docs.

### Description

- Updated `README.md` to explain that the CLI analyzes the configured `.sln`/`.slnx` and writes a fenced Markdown Mermaid block to `output.file`, and that the VSIX creates a starter config if the file is missing next to the solution.
- Rewrote `docs/cli.md` to match the CLI implementation: default config lookup only includes `slnx-mermaid.yml`, `--config` usage, help verification command, and that the command prints and writes Markdown-wrapped Mermaid output.
- Expanded `docs/configuration.md` to document normalized project ids (file name without extension with dots/hyphens -> underscores), case-insensitive substring filters, UI mapping key format, alias constraints, path resolution (resolved from config file location) and the fallback solution parsing behavior used when MSBuild project evaluation fails.
- Updated `docs/vsix.md` and `docs/vsix/GETTING_STARTED.md` to reflect VSIX behavior: it looks for or bootstraps `slnx-mermaid.yml` next to the loaded solution, writes the configured Markdown output file and opens it automatically; also removed duplicate badge block.
- Corrected sample mapping keys in `docs/configuration.md` and `slnx-mermaid.yml` from `SlnxMermaid.CLI`/`SlnxMermaid.Core` to the normalized ids `SlnxMermaid_CLI`/`SlnxMermaid_Core` and aligned aliases example.

### Testing

- Ran `git diff --check` to validate whitespace and basic diff sanity; it reported no issues (success).
- Attempted to run `dotnet test`, but the environment lacks the `dotnet` runtime/toolchain so unit tests could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a35e8e048324885174e3f6069ab5)