### PR TITLE
ci: add dotnet format check

### DIFF
--- a/.github/workflows/CI-dotnet-format.yml
+++ b/.github/workflows/CI-dotnet-format.yml
@@ -1,0 +1,38 @@
+name: CI-dotnet-format
+
+on:
+  workflow_call:
+    inputs:
+      dotnet_version:
+        type: string
+        default: 10.0.x
+
+jobs:
+  dotnet-format:
+    name: Check .NET formatting
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore SlnxMermaid.slnx
+
+      - name: Verify formatting
+        run: dotnet format SlnxMermaid.slnx --no-restore --verify-no-changes --verbosity diagnostic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,9 @@ jobs:
   CI-build-linux-net10:
     uses: ./.github/workflows/CI-build-linux-net10.yml
 
+  CI-dotnet-format:
+    uses: ./.github/workflows/CI-dotnet-format.yml
+
   CI-check-mermaid:
     needs: CI-build-linux-net10
     if: github.event_name != 'schedule'

--- a/src/SlnxMermaid.Configuration/Exceptions/ConfigurationFileNotFoundException.cs
+++ b/src/SlnxMermaid.Configuration/Exceptions/ConfigurationFileNotFoundException.cs
@@ -7,9 +7,9 @@ namespace SlnxMermaid.Core.Exceptions
         public string FilePath { get; }
 
         public ConfigurationFileNotFoundException(string filePath) : base($"Configuration file not found: {filePath}")
-        { 
+        {
             FilePath = filePath;
         }
     }
-    
+
 }

--- a/src/SlnxMermaid.Configuration/Exceptions/YamlDeserializeException.cs
+++ b/src/SlnxMermaid.Configuration/Exceptions/YamlDeserializeException.cs
@@ -11,5 +11,5 @@ namespace SlnxMermaid.Core.Exceptions
             FilePath = filePath;
         }
     }
-    
+
 }

--- a/src/SlnxMermaid.Core/Emit/DependencyDepthGraph.cs
+++ b/src/SlnxMermaid.Core/Emit/DependencyDepthGraph.cs
@@ -7,148 +7,148 @@ using SlnxMermaid.Core.Naming;
 
 namespace SlnxMermaid.Core.Emit
 {
-internal sealed class DependencyDepthGraph
-{
-    private readonly IReadOnlyDictionary<string, List<string>> _dependenciesById;
-    private readonly IReadOnlyCollection<string> _nodeIds;
-    private readonly Dictionary<string, int> _depthById = new Dictionary<string, int>(StringComparer.Ordinal);
-
-    internal DependencyDepthGraph(
-        IReadOnlyCollection<string> nodeIds,
-        IReadOnlyDictionary<string, List<string>> dependenciesById)
+    internal sealed class DependencyDepthGraph
     {
-        _nodeIds = nodeIds;
-        _dependenciesById = dependenciesById;
-    }
+        private readonly IReadOnlyDictionary<string, List<string>> _dependenciesById;
+        private readonly IReadOnlyCollection<string> _nodeIds;
+        private readonly Dictionary<string, int> _depthById = new Dictionary<string, int>(StringComparer.Ordinal);
 
-    internal static DependencyDepthGraph Create(
-        IEnumerable<ProjectNode> nodes,
-        ProjectFilter filter)
-    {
-        var allowedNodes = nodes
-            .Where(node => filter.IsAllowed(node.Id))
-            .GroupBy(node => node.Id, StringComparer.Ordinal)
-            .Select(group => group.OrderBy(node => node.Path, StringComparer.OrdinalIgnoreCase).First())
-            .OrderBy(node => node.Id, StringComparer.Ordinal)
-            .ToList();
-
-        var allowedIds = new HashSet<string>(allowedNodes.Select(node => node.Id), StringComparer.Ordinal);
-        var dependenciesById = allowedNodes.ToDictionary(
-            node => node.Id,
-            node => node.Dependencies
-                .Where(dependency => allowedIds.Contains(dependency.Id))
-                .Select(dependency => dependency.Id)
-                .Distinct(StringComparer.Ordinal)
-                .OrderBy(id => id, StringComparer.Ordinal)
-                .ToList(),
-            StringComparer.Ordinal);
-
-        return new DependencyDepthGraph(allowedIds.ToList(), dependenciesById);
-    }
-
-    internal IEnumerable<DepthOrderedEdge> GetDepthOrderedEdges(NameTransformer naming)
-    {
-        var emittedEdges = new HashSet<LegacyEdge>(LegacyEdgeComparer.Instance);
-
-        foreach (var rootId in GetTraversalRoots())
+        internal DependencyDepthGraph(
+            IReadOnlyCollection<string> nodeIds,
+            IReadOnlyDictionary<string, List<string>> dependenciesById)
         {
-            foreach (var edge in TraverseBreadthFirst(rootId, naming, emittedEdges))
-                yield return edge;
+            _nodeIds = nodeIds;
+            _dependenciesById = dependenciesById;
         }
-    }
 
-    private IEnumerable<string> GetTraversalRoots()
-    {
-        var incomingCountById = _nodeIds.ToDictionary(id => id, id => 0, StringComparer.Ordinal);
-
-        foreach (var dependencyId in _dependenciesById.SelectMany(pair => pair.Value))
-            incomingCountById[dependencyId]++;
-
-        var rootIds = incomingCountById
-            .Where(pair => pair.Value == 0)
-            .Select(pair => pair.Key)
-            .OrderByDescending(GetDependencyDepth)
-            .ThenBy(id => id, StringComparer.Ordinal)
-            .ToList();
-
-        var nonRootIds = _nodeIds
-            .Except(rootIds, StringComparer.Ordinal)
-            .OrderByDescending(GetDependencyDepth)
-            .ThenBy(id => id, StringComparer.Ordinal);
-
-        return rootIds.Concat(nonRootIds);
-    }
-
-    private IEnumerable<DepthOrderedEdge> TraverseBreadthFirst(
-        string rootId,
-        NameTransformer naming,
-        ISet<LegacyEdge> emittedEdges)
-    {
-        var visitedSources = new HashSet<string>(StringComparer.Ordinal);
-        var queuedSources = new HashSet<string>(StringComparer.Ordinal);
-        var queue = new Queue<string>();
-
-        queue.Enqueue(rootId);
-        queuedSources.Add(rootId);
-
-        while (queue.Count > 0)
+        internal static DependencyDepthGraph Create(
+            IEnumerable<ProjectNode> nodes,
+            ProjectFilter filter)
         {
-            var sourceId = queue.Dequeue();
+            var allowedNodes = nodes
+                .Where(node => filter.IsAllowed(node.Id))
+                .GroupBy(node => node.Id, StringComparer.Ordinal)
+                .Select(group => group.OrderBy(node => node.Path, StringComparer.OrdinalIgnoreCase).First())
+                .OrderBy(node => node.Id, StringComparer.Ordinal)
+                .ToList();
 
-            if (!visitedSources.Add(sourceId))
-                continue;
+            var allowedIds = new HashSet<string>(allowedNodes.Select(node => node.Id), StringComparer.Ordinal);
+            var dependenciesById = allowedNodes.ToDictionary(
+                node => node.Id,
+                node => node.Dependencies
+                    .Where(dependency => allowedIds.Contains(dependency.Id))
+                    .Select(dependency => dependency.Id)
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToList(),
+                StringComparer.Ordinal);
 
-            foreach (var dependencyId in _dependenciesById[sourceId])
+            return new DependencyDepthGraph(allowedIds.ToList(), dependenciesById);
+        }
+
+        internal IEnumerable<DepthOrderedEdge> GetDepthOrderedEdges(NameTransformer naming)
+        {
+            var emittedEdges = new HashSet<LegacyEdge>(LegacyEdgeComparer.Instance);
+
+            foreach (var rootId in GetTraversalRoots())
             {
-                var edgeKey = new LegacyEdge(sourceId, dependencyId);
-
-                if (emittedEdges.Add(edgeKey))
-                {
-                    yield return new DepthOrderedEdge(
-                        rootId,
-                        sourceId,
-                        naming.Transform(sourceId),
-                        naming.Transform(dependencyId));
-                }
-
-                if (queuedSources.Add(dependencyId))
-                    queue.Enqueue(dependencyId);
+                foreach (var edge in TraverseBreadthFirst(rootId, naming, emittedEdges))
+                    yield return edge;
             }
         }
-    }
 
-    private int GetDependencyDepth(string nodeId)
-    {
-        int depth;
+        private IEnumerable<string> GetTraversalRoots()
+        {
+            var incomingCountById = _nodeIds.ToDictionary(id => id, id => 0, StringComparer.Ordinal);
 
-        if (_depthById.TryGetValue(nodeId, out depth))
+            foreach (var dependencyId in _dependenciesById.SelectMany(pair => pair.Value))
+                incomingCountById[dependencyId]++;
+
+            var rootIds = incomingCountById
+                .Where(pair => pair.Value == 0)
+                .Select(pair => pair.Key)
+                .OrderByDescending(GetDependencyDepth)
+                .ThenBy(id => id, StringComparer.Ordinal)
+                .ToList();
+
+            var nonRootIds = _nodeIds
+                .Except(rootIds, StringComparer.Ordinal)
+                .OrderByDescending(GetDependencyDepth)
+                .ThenBy(id => id, StringComparer.Ordinal);
+
+            return rootIds.Concat(nonRootIds);
+        }
+
+        private IEnumerable<DepthOrderedEdge> TraverseBreadthFirst(
+            string rootId,
+            NameTransformer naming,
+            ISet<LegacyEdge> emittedEdges)
+        {
+            var visitedSources = new HashSet<string>(StringComparer.Ordinal);
+            var queuedSources = new HashSet<string>(StringComparer.Ordinal);
+            var queue = new Queue<string>();
+
+            queue.Enqueue(rootId);
+            queuedSources.Add(rootId);
+
+            while (queue.Count > 0)
+            {
+                var sourceId = queue.Dequeue();
+
+                if (!visitedSources.Add(sourceId))
+                    continue;
+
+                foreach (var dependencyId in _dependenciesById[sourceId])
+                {
+                    var edgeKey = new LegacyEdge(sourceId, dependencyId);
+
+                    if (emittedEdges.Add(edgeKey))
+                    {
+                        yield return new DepthOrderedEdge(
+                            rootId,
+                            sourceId,
+                            naming.Transform(sourceId),
+                            naming.Transform(dependencyId));
+                    }
+
+                    if (queuedSources.Add(dependencyId))
+                        queue.Enqueue(dependencyId);
+                }
+            }
+        }
+
+        private int GetDependencyDepth(string nodeId)
+        {
+            int depth;
+
+            if (_depthById.TryGetValue(nodeId, out depth))
+                return depth;
+
+            depth = GetDependencyDepth(nodeId, new HashSet<string>(StringComparer.Ordinal));
+            _depthById[nodeId] = depth;
+
             return depth;
+        }
 
-        depth = GetDependencyDepth(nodeId, new HashSet<string>(StringComparer.Ordinal));
-        _depthById[nodeId] = depth;
+        private int GetDependencyDepth(string nodeId, ISet<string> activePath)
+        {
+            int depth;
 
-        return depth;
-    }
+            if (_depthById.TryGetValue(nodeId, out depth))
+                return depth;
 
-    private int GetDependencyDepth(string nodeId, ISet<string> activePath)
-    {
-        int depth;
+            if (!activePath.Add(nodeId))
+                return 0;
 
-        if (_depthById.TryGetValue(nodeId, out depth))
+            depth = 0;
+
+            foreach (var dependencyId in _dependenciesById[nodeId])
+                depth = Math.Max(depth, 1 + GetDependencyDepth(dependencyId, activePath));
+
+            activePath.Remove(nodeId);
+            _depthById[nodeId] = depth;
+
             return depth;
-
-        if (!activePath.Add(nodeId))
-            return 0;
-
-        depth = 0;
-
-        foreach (var dependencyId in _dependenciesById[nodeId])
-            depth = Math.Max(depth, 1 + GetDependencyDepth(dependencyId, activePath));
-
-        activePath.Remove(nodeId);
-        _depthById[nodeId] = depth;
-
-        return depth;
+        }
     }
-}
 }

--- a/src/SlnxMermaid.Core/Emit/DepthOrderedEdge.cs
+++ b/src/SlnxMermaid.Core/Emit/DepthOrderedEdge.cs
@@ -1,22 +1,22 @@
 ﻿namespace SlnxMermaid.Core.Emit
 {
-internal sealed class DepthOrderedEdge
-{
-    internal DepthOrderedEdge(
-        string rootId,
-        string sourceId,
-        string from,
-        string to)
+    internal sealed class DepthOrderedEdge
     {
-        RootId = rootId;
-        SourceId = sourceId;
-        From = from;
-        To = to;
-    }
+        internal DepthOrderedEdge(
+            string rootId,
+            string sourceId,
+            string from,
+            string to)
+        {
+            RootId = rootId;
+            SourceId = sourceId;
+            From = from;
+            To = to;
+        }
 
-    internal string RootId { get; }
-    internal string SourceId { get; }
-    internal string From { get; }
-    internal string To { get; }
-}
+        internal string RootId { get; }
+        internal string SourceId { get; }
+        internal string From { get; }
+        internal string To { get; }
+    }
 }

--- a/src/SlnxMermaid.Core/Emit/LegacyEdge.cs
+++ b/src/SlnxMermaid.Core/Emit/LegacyEdge.cs
@@ -1,14 +1,14 @@
 ﻿namespace SlnxMermaid.Core.Emit
 {
-internal sealed class LegacyEdge
-{
-    internal LegacyEdge(string from, string to)
+    internal sealed class LegacyEdge
     {
-        From = from;
-        To = to;
-    }
+        internal LegacyEdge(string from, string to)
+        {
+            From = from;
+            To = to;
+        }
 
-    internal string From { get; }
-    internal string To { get; }
-}
+        internal string From { get; }
+        internal string To { get; }
+    }
 }

--- a/src/SlnxMermaid.Core/Emit/LegacyEdgeComparer.cs
+++ b/src/SlnxMermaid.Core/Emit/LegacyEdgeComparer.cs
@@ -3,29 +3,29 @@ using System.Collections.Generic;
 
 namespace SlnxMermaid.Core.Emit
 {
-internal sealed class LegacyEdgeComparer : IEqualityComparer<LegacyEdge>
-{
-    internal static readonly LegacyEdgeComparer Instance = new LegacyEdgeComparer();
-
-    public bool Equals(LegacyEdge x, LegacyEdge y)
+    internal sealed class LegacyEdgeComparer : IEqualityComparer<LegacyEdge>
     {
-        if (ReferenceEquals(x, y))
-            return true;
+        internal static readonly LegacyEdgeComparer Instance = new LegacyEdgeComparer();
 
-        if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
-            return false;
-
-        return string.Equals(x.From, y.From, StringComparison.Ordinal) &&
-            string.Equals(x.To, y.To, StringComparison.Ordinal);
-    }
-
-    public int GetHashCode(LegacyEdge obj)
-    {
-        unchecked
+        public bool Equals(LegacyEdge x, LegacyEdge y)
         {
-            return ((obj.From != null ? StringComparer.Ordinal.GetHashCode(obj.From) : 0) * 397) ^
-                (obj.To != null ? StringComparer.Ordinal.GetHashCode(obj.To) : 0);
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                return false;
+
+            return string.Equals(x.From, y.From, StringComparison.Ordinal) &&
+                string.Equals(x.To, y.To, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(LegacyEdge obj)
+        {
+            unchecked
+            {
+                return ((obj.From != null ? StringComparer.Ordinal.GetHashCode(obj.From) : 0) * 397) ^
+                    (obj.To != null ? StringComparer.Ordinal.GetHashCode(obj.To) : 0);
+            }
         }
     }
-}
 }

--- a/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidEmitter.cs
@@ -10,260 +10,260 @@ using SlnxMermaid.Core.Naming;
 
 namespace SlnxMermaid.Core.Emit
 {
-public sealed class MermaidEmitter
-{
-    private readonly NameTransformer _naming;
-    private readonly ProjectFilter _filter;
-
-    public MermaidEmitter(
-        NameTransformer naming,
-        ProjectFilter filter)
+    public sealed class MermaidEmitter
     {
-        if (naming == null)
-            throw new ArgumentNullException(nameof(naming));
+        private readonly NameTransformer _naming;
+        private readonly ProjectFilter _filter;
 
-        if (filter == null)
-            throw new ArgumentNullException(nameof(filter));
-
-        _naming = naming;
-        _filter = filter;
-    }
-
-    public string Emit(
-        IEnumerable<ProjectNode> nodes,
-        SlnxMermaidConfig config)
-    {
-        if (nodes == null)
-            throw new ArgumentNullException(nameof(nodes));
-
-        if (config == null)
-            throw new ArgumentNullException(nameof(config));
-
-        return Emit(nodes, config.Diagram, config.Ui);
-    }
-
-    private string Emit(
-        IEnumerable<ProjectNode> nodes,
-        DiagramConfig diagram,
-        UiConfig ui)
-    {
-        if (nodes == null)
-            throw new ArgumentNullException(nameof(nodes));
-
-        if (diagram == null)
-            throw new ArgumentNullException(nameof(diagram));
-
-        var nodeList = nodes.ToList();
-        var sb = new StringBuilder();
-        sb.AppendLine($"graph {diagram.Direction}");
-
-        if (diagram.OrderDependenciesByDepth)
+        public MermaidEmitter(
+            NameTransformer naming,
+            ProjectFilter filter)
         {
-            var orderedEdges = OrderEdgesByDependencyDepth(nodeList).ToList();
+            if (naming == null)
+                throw new ArgumentNullException(nameof(naming));
 
-            if (orderedEdges.Count > 0)
-                sb.AppendLine();
+            if (filter == null)
+                throw new ArgumentNullException(nameof(filter));
 
-            for (var i = 0; i < orderedEdges.Count; i++)
+            _naming = naming;
+            _filter = filter;
+        }
+
+        public string Emit(
+            IEnumerable<ProjectNode> nodes,
+            SlnxMermaidConfig config)
+        {
+            if (nodes == null)
+                throw new ArgumentNullException(nameof(nodes));
+
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            return Emit(nodes, config.Diagram, config.Ui);
+        }
+
+        private string Emit(
+            IEnumerable<ProjectNode> nodes,
+            DiagramConfig diagram,
+            UiConfig ui)
+        {
+            if (nodes == null)
+                throw new ArgumentNullException(nameof(nodes));
+
+            if (diagram == null)
+                throw new ArgumentNullException(nameof(diagram));
+
+            var nodeList = nodes.ToList();
+            var sb = new StringBuilder();
+            sb.AppendLine($"graph {diagram.Direction}");
+
+            if (diagram.OrderDependenciesByDepth)
             {
-                if (i > 0 && !string.Equals(orderedEdges[i].SourceId, orderedEdges[i - 1].SourceId, StringComparison.Ordinal))
+                var orderedEdges = OrderEdgesByDependencyDepth(nodeList).ToList();
+
+                if (orderedEdges.Count > 0)
                     sb.AppendLine();
 
-                AppendEdge(sb, orderedEdges[i]);
+                for (var i = 0; i < orderedEdges.Count; i++)
+                {
+                    if (i > 0 && !string.Equals(orderedEdges[i].SourceId, orderedEdges[i - 1].SourceId, StringComparison.Ordinal))
+                        sb.AppendLine();
+
+                    AppendEdge(sb, orderedEdges[i]);
+                }
             }
-        }
-        else
-        {
-            foreach (var edge in GetLegacySortedEdges(nodeList))
-                AppendEdge(sb, edge);
-        }
-
-        if (ui != null)
-            AppendNodeStyles(sb, nodeList, ui);
-
-        return sb.ToString();
-    }
-
-    private void AppendNodeStyles(StringBuilder sb, IEnumerable<ProjectNode> nodes, UiConfig ui)
-    {
-        if (sb == null)
-            throw new ArgumentNullException(nameof(sb));
-
-        if (nodes == null)
-            throw new ArgumentNullException(nameof(nodes));
-
-        if (ui == null)
-            throw new ArgumentNullException(nameof(ui));
-
-        var visibleNodes = nodes
-            .Where(node => _filter.IsAllowed(node.Id))
-            .OrderBy(node => _naming.Transform(node.Id), StringComparer.Ordinal);
-
-        var resolver = new MermaidNodeStyleResolver(ui);
-        // Keep style state scoped to a single Emit call so concurrent callers never share mutable collections.
-        var classNamesByStyle = new Dictionary<MermaidNodeStyle, string>();
-        var classDefinitions = new List<KeyValuePair<string, MermaidNodeStyle>>();
-        var usedClassNames = new HashSet<string>(StringComparer.Ordinal);
-        var assignments = new List<KeyValuePair<string, string>>();
-
-        foreach (var node in visibleNodes)
-        {
-            var resolved = resolver.Resolve(node.Id);
-            string className;
-            if (!classNamesByStyle.TryGetValue(resolved.Style, out className))
+            else
             {
-                className = CreateUniqueClassName(resolved, usedClassNames);
-                classNamesByStyle[resolved.Style] = className;
-                classDefinitions.Add(new KeyValuePair<string, MermaidNodeStyle>(className, resolved.Style));
+                foreach (var edge in GetLegacySortedEdges(nodeList))
+                    AppendEdge(sb, edge);
             }
 
-            assignments.Add(new KeyValuePair<string, string>(_naming.Transform(node.Id), className));
+            if (ui != null)
+                AppendNodeStyles(sb, nodeList, ui);
+
+            return sb.ToString();
         }
 
-        if (assignments.Count == 0)
+        private void AppendNodeStyles(StringBuilder sb, IEnumerable<ProjectNode> nodes, UiConfig ui)
         {
-            LogWarning("No visible nodes to process. Check your filters and inputs.");
-            return;
-        }
+            if (sb == null)
+                throw new ArgumentNullException(nameof(sb));
 
-        sb.AppendLine();
+            if (nodes == null)
+                throw new ArgumentNullException(nameof(nodes));
 
-        foreach (var definition in classDefinitions)
-            AppendClass(sb, definition);
+            if (ui == null)
+                throw new ArgumentNullException(nameof(ui));
 
-        sb.AppendLine();
+            var visibleNodes = nodes
+                .Where(node => _filter.IsAllowed(node.Id))
+                .OrderBy(node => _naming.Transform(node.Id), StringComparer.Ordinal);
 
-        foreach (var assignment in assignments)
-            AppendClassAssignment(sb, assignment);
-    }
+            var resolver = new MermaidNodeStyleResolver(ui);
+            // Keep style state scoped to a single Emit call so concurrent callers never share mutable collections.
+            var classNamesByStyle = new Dictionary<MermaidNodeStyle, string>();
+            var classDefinitions = new List<KeyValuePair<string, MermaidNodeStyle>>();
+            var usedClassNames = new HashSet<string>(StringComparer.Ordinal);
+            var assignments = new List<KeyValuePair<string, string>>();
 
-    private static string CreateUniqueClassName(
-        MermaidNodeResolvedStyle resolved,
-        HashSet<string> usedClassNames)
-    {
-        if (resolved == null)
-            throw new ArgumentNullException(nameof(resolved));
-
-        if (usedClassNames == null)
-            throw new ArgumentNullException(nameof(usedClassNames));
-
-        var className = CreateClassName(resolved);
-        var originalClassName = className;
-        var suffix = 2;
-        while (usedClassNames.Contains(className))
-        {
-            className = originalClassName + "_" + suffix;
-            suffix++;
-        }
-
-        usedClassNames.Add(className);
-        return className;
-    }
-
-    private static string CreateClassName(MermaidNodeResolvedStyle resolved)
-    {
-        if (resolved == null)
-            throw new ArgumentNullException(nameof(resolved));
-
-        var baseName = string.IsNullOrWhiteSpace(resolved.BaseName) ? "style" : SanitizeClassToken(resolved.BaseName);
-        if (!resolved.Custom)
-            return "cls_" + baseName;
-
-        return "cls_" + baseName + "_custom_" + resolved.Style.Fill.TrimStart('#').ToLowerInvariant();
-    }
-
-    private static string SanitizeClassToken(string value)
-    {
-        if (value == null)
-            throw new ArgumentNullException(nameof(value));
-
-        // Mermaid class names generated here are intentionally limited to ASCII lowercase letters,
-        // digits, and underscores so the emitted classDef/class references remain parser-friendly.
-        var sanitized = Regex.Replace(value.ToLowerInvariant(), "[^a-z0-9_]+", "_").Trim('_');
-        return string.IsNullOrEmpty(sanitized) ? "style" : sanitized;
-    }
-
-    private static void AppendEdge(StringBuilder sb, LegacyEdge edge)
-    {
-        if (sb == null)
-            throw new ArgumentNullException(nameof(sb));
-
-        if (edge == null)
-            throw new ArgumentNullException(nameof(edge));
-
-        sb.AppendLine($"    {edge.From} --> {edge.To}");
-    }
-
-    private static void AppendEdge(StringBuilder sb, DepthOrderedEdge edge)
-    {
-        if (sb == null)
-            throw new ArgumentNullException(nameof(sb));
-
-        if (edge == null)
-            throw new ArgumentNullException(nameof(edge));
-
-        sb.AppendLine($"    {edge.From} --> {edge.To}");
-    }
-
-    private static void AppendClass(StringBuilder sb, KeyValuePair<string, MermaidNodeStyle> definition)
-    {
-        if (sb == null)
-            throw new ArgumentNullException(nameof(sb));
-
-        var style = definition.Value;
-        sb.AppendLine($"    classDef {definition.Key} fill:{style.Fill},stroke:{style.Stroke},color:{style.Color}");
-    }
-
-    private static void AppendClassAssignment(StringBuilder sb, KeyValuePair<string, string> assignment)
-    {
-        if (sb == null)
-            throw new ArgumentNullException(nameof(sb));
-
-        sb.AppendLine($"    class {assignment.Key} {assignment.Value}");
-    }
-
-    private static void LogWarning(string message)
-    {
-        Console.WriteLine("[WARNING]: " + message);
-    }
-
-    private IEnumerable<LegacyEdge> GetLegacySortedEdges(IEnumerable<ProjectNode> nodes)
-    {
-        if (nodes == null)
-            throw new ArgumentNullException(nameof(nodes));
-
-        var edges = new HashSet<LegacyEdge>(LegacyEdgeComparer.Instance);
-
-        foreach (var node in nodes)
-        {
-            if (!_filter.IsAllowed(node.Id))
-                continue;
-
-            var from = _naming.Transform(node.Id);
-
-            foreach (var depId in node.Dependencies.Select(dep => dep.Id))
+            foreach (var node in visibleNodes)
             {
-                if (!_filter.IsAllowed(depId))
+                var resolved = resolver.Resolve(node.Id);
+                string className;
+                if (!classNamesByStyle.TryGetValue(resolved.Style, out className))
+                {
+                    className = CreateUniqueClassName(resolved, usedClassNames);
+                    classNamesByStyle[resolved.Style] = className;
+                    classDefinitions.Add(new KeyValuePair<string, MermaidNodeStyle>(className, resolved.Style));
+                }
+
+                assignments.Add(new KeyValuePair<string, string>(_naming.Transform(node.Id), className));
+            }
+
+            if (assignments.Count == 0)
+            {
+                LogWarning("No visible nodes to process. Check your filters and inputs.");
+                return;
+            }
+
+            sb.AppendLine();
+
+            foreach (var definition in classDefinitions)
+                AppendClass(sb, definition);
+
+            sb.AppendLine();
+
+            foreach (var assignment in assignments)
+                AppendClassAssignment(sb, assignment);
+        }
+
+        private static string CreateUniqueClassName(
+            MermaidNodeResolvedStyle resolved,
+            HashSet<string> usedClassNames)
+        {
+            if (resolved == null)
+                throw new ArgumentNullException(nameof(resolved));
+
+            if (usedClassNames == null)
+                throw new ArgumentNullException(nameof(usedClassNames));
+
+            var className = CreateClassName(resolved);
+            var originalClassName = className;
+            var suffix = 2;
+            while (usedClassNames.Contains(className))
+            {
+                className = originalClassName + "_" + suffix;
+                suffix++;
+            }
+
+            usedClassNames.Add(className);
+            return className;
+        }
+
+        private static string CreateClassName(MermaidNodeResolvedStyle resolved)
+        {
+            if (resolved == null)
+                throw new ArgumentNullException(nameof(resolved));
+
+            var baseName = string.IsNullOrWhiteSpace(resolved.BaseName) ? "style" : SanitizeClassToken(resolved.BaseName);
+            if (!resolved.Custom)
+                return "cls_" + baseName;
+
+            return "cls_" + baseName + "_custom_" + resolved.Style.Fill.TrimStart('#').ToLowerInvariant();
+        }
+
+        private static string SanitizeClassToken(string value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            // Mermaid class names generated here are intentionally limited to ASCII lowercase letters,
+            // digits, and underscores so the emitted classDef/class references remain parser-friendly.
+            var sanitized = Regex.Replace(value.ToLowerInvariant(), "[^a-z0-9_]+", "_").Trim('_');
+            return string.IsNullOrEmpty(sanitized) ? "style" : sanitized;
+        }
+
+        private static void AppendEdge(StringBuilder sb, LegacyEdge edge)
+        {
+            if (sb == null)
+                throw new ArgumentNullException(nameof(sb));
+
+            if (edge == null)
+                throw new ArgumentNullException(nameof(edge));
+
+            sb.AppendLine($"    {edge.From} --> {edge.To}");
+        }
+
+        private static void AppendEdge(StringBuilder sb, DepthOrderedEdge edge)
+        {
+            if (sb == null)
+                throw new ArgumentNullException(nameof(sb));
+
+            if (edge == null)
+                throw new ArgumentNullException(nameof(edge));
+
+            sb.AppendLine($"    {edge.From} --> {edge.To}");
+        }
+
+        private static void AppendClass(StringBuilder sb, KeyValuePair<string, MermaidNodeStyle> definition)
+        {
+            if (sb == null)
+                throw new ArgumentNullException(nameof(sb));
+
+            var style = definition.Value;
+            sb.AppendLine($"    classDef {definition.Key} fill:{style.Fill},stroke:{style.Stroke},color:{style.Color}");
+        }
+
+        private static void AppendClassAssignment(StringBuilder sb, KeyValuePair<string, string> assignment)
+        {
+            if (sb == null)
+                throw new ArgumentNullException(nameof(sb));
+
+            sb.AppendLine($"    class {assignment.Key} {assignment.Value}");
+        }
+
+        private static void LogWarning(string message)
+        {
+            Console.WriteLine("[WARNING]: " + message);
+        }
+
+        private IEnumerable<LegacyEdge> GetLegacySortedEdges(IEnumerable<ProjectNode> nodes)
+        {
+            if (nodes == null)
+                throw new ArgumentNullException(nameof(nodes));
+
+            var edges = new HashSet<LegacyEdge>(LegacyEdgeComparer.Instance);
+
+            foreach (var node in nodes)
+            {
+                if (!_filter.IsAllowed(node.Id))
                     continue;
 
-                var to = _naming.Transform(depId);
-                edges.Add(new LegacyEdge(from, to));
+                var from = _naming.Transform(node.Id);
+
+                foreach (var depId in node.Dependencies.Select(dep => dep.Id))
+                {
+                    if (!_filter.IsAllowed(depId))
+                        continue;
+
+                    var to = _naming.Transform(depId);
+                    edges.Add(new LegacyEdge(from, to));
+                }
             }
+
+            return edges
+                .OrderBy(edge => edge.From, StringComparer.Ordinal)
+                .ThenBy(edge => edge.To, StringComparer.Ordinal);
         }
 
-        return edges
-            .OrderBy(edge => edge.From, StringComparer.Ordinal)
-            .ThenBy(edge => edge.To, StringComparer.Ordinal);
+        private IEnumerable<DepthOrderedEdge> OrderEdgesByDependencyDepth(IEnumerable<ProjectNode> nodes)
+        {
+            if (nodes == null)
+                throw new ArgumentNullException(nameof(nodes));
+
+            return DependencyDepthGraph.Create(nodes, _filter)
+                .GetDepthOrderedEdges(_naming);
+        }
+
     }
-
-    private IEnumerable<DepthOrderedEdge> OrderEdgesByDependencyDepth(IEnumerable<ProjectNode> nodes)
-    {
-        if (nodes == null)
-            throw new ArgumentNullException(nameof(nodes));
-
-        return DependencyDepthGraph.Create(nodes, _filter)
-            .GetDepthOrderedEdges(_naming);
-    }
-
-}
 }

--- a/src/SlnxMermaid.Core/Emit/MermaidNodeStyle.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidNodeStyle.cs
@@ -2,51 +2,51 @@ using System;
 
 namespace SlnxMermaid.Core.Emit
 {
-public sealed class MermaidNodeStyle : IEquatable<MermaidNodeStyle>
-{
-    public MermaidNodeStyle(string fill, string stroke, string color)
+    public sealed class MermaidNodeStyle : IEquatable<MermaidNodeStyle>
     {
-        Fill = fill;
-        Stroke = stroke;
-        Color = color;
-    }
-
-    public string Fill { get; private set; }
-
-    public string Stroke { get; private set; }
-
-    public string Color { get; private set; }
-
-    public bool Equals(MermaidNodeStyle other)
-    {
-        if (other == null)
-            return false;
-
-        return string.Equals(Fill, other.Fill, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(Stroke, other.Stroke, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(Color, other.Color, StringComparison.OrdinalIgnoreCase);
-    }
-
-    public override bool Equals(object obj)
-    {
-        return Equals(obj as MermaidNodeStyle);
-    }
-
-    public override int GetHashCode()
-    {
-        unchecked
+        public MermaidNodeStyle(string fill, string stroke, string color)
         {
-            var hash = 17;
-            hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Fill ?? string.Empty);
-            hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Stroke ?? string.Empty);
-            hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Color ?? string.Empty);
-            return hash;
+            Fill = fill;
+            Stroke = stroke;
+            Color = color;
+        }
+
+        public string Fill { get; private set; }
+
+        public string Stroke { get; private set; }
+
+        public string Color { get; private set; }
+
+        public bool Equals(MermaidNodeStyle other)
+        {
+            if (other == null)
+                return false;
+
+            return string.Equals(Fill, other.Fill, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(Stroke, other.Stroke, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(Color, other.Color, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as MermaidNodeStyle);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Fill ?? string.Empty);
+                hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Stroke ?? string.Empty);
+                hash = hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(Color ?? string.Empty);
+                return hash;
+            }
+        }
+
+        public MermaidNodeStyle With(string fill, string stroke, string color)
+        {
+            return new MermaidNodeStyle(fill ?? Fill, stroke ?? Stroke, color ?? Color);
         }
     }
-
-    public MermaidNodeStyle With(string fill, string stroke, string color)
-    {
-        return new MermaidNodeStyle(fill ?? Fill, stroke ?? Stroke, color ?? Color);
-    }
-}
 }

--- a/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
@@ -8,101 +8,101 @@ using SlnxMermaid.Core.Config;
 
 namespace SlnxMermaid.Core.Emit
 {
-public sealed class MermaidNodeStyleResolver
-{
-    private static readonly Regex HexRegex = new Regex("^#[0-9a-fA-F]{6}$", RegexOptions.Compiled);
-    private static readonly string[] FallbackColorOrder = { "blue", "green", "yellow", "orange", "pink", "purple", "gray", "red" };
-
-    private readonly UiConfig _ui;
-    private readonly MermaidPalette _palette;
-    private readonly Dictionary<string, string> _semantic;
-
-    public MermaidNodeStyleResolver(UiConfig ui)
+    public sealed class MermaidNodeStyleResolver
     {
-        _ui = ui ?? new UiConfig();
-        _palette = MermaidPalette.ForMode(_ui.Mode);
-        _semantic = BuildSemanticMap(_ui.Semantic);
-        ValidateSemanticColors();
-        ValidateMappings();
-    }
+        private static readonly Regex HexRegex = new Regex("^#[0-9a-fA-F]{6}$", RegexOptions.Compiled);
+        private static readonly string[] FallbackColorOrder = { "blue", "green", "yellow", "orange", "pink", "purple", "gray", "red" };
 
-    public MermaidNodeResolvedStyle Resolve(string projectName)
-    {
-        var role = DetectRole(projectName);
-        var baseColorName = role != null ? _semantic[role] : null;
-        var baseStyle = baseColorName != null ? _palette.Get(baseColorName) : ResolveFallback(projectName);
+        private readonly UiConfig _ui;
+        private readonly MermaidPalette _palette;
+        private readonly Dictionary<string, string> _semantic;
 
-        object mappingValue;
-        string mappingKey;
-        if (TryGetExactMapping(projectName, out mappingKey, out mappingValue) || TryGetWildcardMapping(projectName, out mappingKey, out mappingValue))
-            return ApplyMapping(mappingValue, baseColorName != null ? baseStyle : null, baseColorName, projectName);
-
-        if (baseColorName != null)
-            return new MermaidNodeResolvedStyle(baseStyle, baseColorName, false);
-
-        return new MermaidNodeResolvedStyle(baseStyle, FallbackColorName(projectName), false);
-    }
-
-    private MermaidNodeResolvedStyle ApplyMapping(object value, MermaidNodeStyle baseStyle, string baseColorName, string projectName)
-    {
-        var text = value as string;
-        if (text != null)
+        public MermaidNodeStyleResolver(UiConfig ui)
         {
-            text = text.Trim();
-            if (LooksLikeHex(text) && !IsHex(text))
-                throw new InvalidOperationException("Invalid hex value '" + text + "'. Expected #RRGGBB.");
+            _ui = ui ?? new UiConfig();
+            _palette = MermaidPalette.ForMode(_ui.Mode);
+            _semantic = BuildSemanticMap(_ui.Semantic);
+            ValidateSemanticColors();
+            ValidateMappings();
+        }
 
-            if (IsHex(text))
+        public MermaidNodeResolvedStyle Resolve(string projectName)
+        {
+            var role = DetectRole(projectName);
+            var baseColorName = role != null ? _semantic[role] : null;
+            var baseStyle = baseColorName != null ? _palette.Get(baseColorName) : ResolveFallback(projectName);
+
+            object mappingValue;
+            string mappingKey;
+            if (TryGetExactMapping(projectName, out mappingKey, out mappingValue) || TryGetWildcardMapping(projectName, out mappingKey, out mappingValue))
+                return ApplyMapping(mappingValue, baseColorName != null ? baseStyle : null, baseColorName, projectName);
+
+            if (baseColorName != null)
+                return new MermaidNodeResolvedStyle(baseStyle, baseColorName, false);
+
+            return new MermaidNodeResolvedStyle(baseStyle, FallbackColorName(projectName), false);
+        }
+
+        private MermaidNodeResolvedStyle ApplyMapping(object value, MermaidNodeStyle baseStyle, string baseColorName, string projectName)
+        {
+            var text = value as string;
+            if (text != null)
             {
-                var style = baseStyle != null
-                    ? baseStyle.With(NormalizeHex(text), null, null)
-                    : AutoStyle(NormalizeHex(text));
-                return new MermaidNodeResolvedStyle(style, baseColorName, true);
+                text = text.Trim();
+                if (LooksLikeHex(text) && !IsHex(text))
+                    throw new InvalidOperationException("Invalid hex value '" + text + "'. Expected #RRGGBB.");
+
+                if (IsHex(text))
+                {
+                    var style = baseStyle != null
+                        ? baseStyle.With(NormalizeHex(text), null, null)
+                        : AutoStyle(NormalizeHex(text));
+                    return new MermaidNodeResolvedStyle(style, baseColorName, true);
+                }
+
+                MermaidNodeStyle paletteStyle;
+                if (!_palette.TryGet(text, out paletteStyle))
+                    throw new InvalidOperationException("Unknown palette color name '" + text + "'.");
+
+                return new MermaidNodeResolvedStyle(paletteStyle, text.ToLowerInvariant(), false);
             }
 
-            MermaidNodeStyle paletteStyle;
-            if (!_palette.TryGet(text, out paletteStyle))
-                throw new InvalidOperationException("Unknown palette color name '" + text + "'.");
+            var values = ToStringObjectDictionary(value);
+            if (values == null)
+                throw new InvalidOperationException("Invalid mapping value type for project '" + projectName + "'. Use a palette name, hex value, or style object.");
 
-            return new MermaidNodeResolvedStyle(paletteStyle, text.ToLowerInvariant(), false);
+            string fill = null;
+            string stroke = null;
+            string color = null;
+
+            foreach (var entry in values)
+            {
+                var field = entry.Key;
+                if (!string.Equals(field, "fill", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(field, "stroke", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(field, "color", StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException("Invalid or unsupported style field '" + field + "'. Allowed fields are fill, stroke, and color.");
+
+                var fieldValue = entry.Value as string;
+                if (fieldValue == null || !IsHex(fieldValue.Trim()))
+                    throw new InvalidOperationException("Invalid hex value for style field '" + field + "'. Expected #RRGGBB.");
+
+                if (string.Equals(field, "fill", StringComparison.OrdinalIgnoreCase))
+                    fill = NormalizeHex(fieldValue);
+                else if (string.Equals(field, "stroke", StringComparison.OrdinalIgnoreCase))
+                    stroke = NormalizeHex(fieldValue);
+                else
+                    color = NormalizeHex(fieldValue);
+            }
+
+            var resolvedBase = baseStyle ?? (fill != null ? AutoStyle(fill) : ResolveFallback(projectName));
+            var resolved = resolvedBase.With(fill, stroke, color);
+            return new MermaidNodeResolvedStyle(resolved, baseColorName ?? FallbackColorName(projectName), fill != null || stroke != null || color != null);
         }
 
-        var values = ToStringObjectDictionary(value);
-        if (values == null)
-            throw new InvalidOperationException("Invalid mapping value type for project '" + projectName + "'. Use a palette name, hex value, or style object.");
-
-        string fill = null;
-        string stroke = null;
-        string color = null;
-
-        foreach (var entry in values)
+        private static Dictionary<string, string> BuildSemanticMap(Dictionary<string, string> configured)
         {
-            var field = entry.Key;
-            if (!string.Equals(field, "fill", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(field, "stroke", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(field, "color", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException("Invalid or unsupported style field '" + field + "'. Allowed fields are fill, stroke, and color.");
-
-            var fieldValue = entry.Value as string;
-            if (fieldValue == null || !IsHex(fieldValue.Trim()))
-                throw new InvalidOperationException("Invalid hex value for style field '" + field + "'. Expected #RRGGBB.");
-
-            if (string.Equals(field, "fill", StringComparison.OrdinalIgnoreCase))
-                fill = NormalizeHex(fieldValue);
-            else if (string.Equals(field, "stroke", StringComparison.OrdinalIgnoreCase))
-                stroke = NormalizeHex(fieldValue);
-            else
-                color = NormalizeHex(fieldValue);
-        }
-
-        var resolvedBase = baseStyle ?? (fill != null ? AutoStyle(fill) : ResolveFallback(projectName));
-        var resolved = resolvedBase.With(fill, stroke, color);
-        return new MermaidNodeResolvedStyle(resolved, baseColorName ?? FallbackColorName(projectName), fill != null || stroke != null || color != null);
-    }
-
-    private static Dictionary<string, string> BuildSemanticMap(Dictionary<string, string> configured)
-    {
-        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             { "presentation", "blue" },
             { "application", "green" },
@@ -113,120 +113,120 @@ public sealed class MermaidNodeStyleResolver
             { "tests", "gray" }
         };
 
-        if (configured != null)
-        {
-            foreach (var entry in configured)
-                result[entry.Key] = entry.Value;
-        }
-
-        return result;
-    }
-
-    private void ValidateSemanticColors()
-    {
-        foreach (var entry in _semantic)
-        {
-            if (string.IsNullOrWhiteSpace(entry.Value) || !_palette.TryGet(entry.Value, out _))
-                throw new InvalidOperationException("Unknown palette color name '" + entry.Value + "' for semantic role '" + entry.Key + "'.");
-        }
-    }
-
-    private void ValidateMappings()
-    {
-        if (_ui.Mappings == null)
-            return;
-
-        foreach (var entry in _ui.Mappings)
-        {
-            if (string.IsNullOrWhiteSpace(entry.Key))
-                throw new InvalidOperationException("Mapping keys cannot be empty.");
-
-            ValidateMappingValue(entry.Key, entry.Value);
-        }
-    }
-
-    private void ValidateMappingValue(string key, object value)
-    {
-        var text = value as string;
-        if (text != null)
-        {
-            text = text.Trim();
-            if (LooksLikeHex(text) && !IsHex(text))
-                throw new InvalidOperationException("Invalid hex value '" + text + "' for mapping '" + key + "'. Expected #RRGGBB.");
-
-            if (IsHex(text))
-                return;
-
-            if (!_palette.TryGet(text, out _))
-                throw new InvalidOperationException("Unknown palette color name '" + text + "' for mapping '" + key + "'.");
-
-            return;
-        }
-
-        var values = ToStringObjectDictionary(value);
-        if (values == null)
-            throw new InvalidOperationException("Invalid mapping value type for mapping '" + key + "'. Use a palette name, hex value, or style object.");
-
-        foreach (var entry in values)
-        {
-            if (!string.Equals(entry.Key, "fill", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(entry.Key, "stroke", StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(entry.Key, "color", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException("Invalid or unsupported style field '" + entry.Key + "'. Allowed fields are fill, stroke, and color.");
-
-            var fieldValue = entry.Value as string;
-            if (fieldValue == null || !IsHex(fieldValue.Trim()))
-                throw new InvalidOperationException("Invalid hex value for style field '" + entry.Key + "' in mapping '" + key + "'. Expected #RRGGBB.");
-        }
-    }
-
-    private bool TryGetExactMapping(string projectName, out string key, out object value)
-    {
-        key = null;
-        value = null;
-        if (_ui.Mappings == null)
-            return false;
-
-        foreach (var entry in _ui.Mappings)
-        {
-            if (entry.Key.IndexOf('*') >= 0)
-                continue;
-
-            if (string.Equals(entry.Key, projectName, StringComparison.Ordinal))
+            if (configured != null)
             {
-                key = entry.Key;
-                value = entry.Value;
-                return true;
+                foreach (var entry in configured)
+                    result[entry.Key] = entry.Value;
+            }
+
+            return result;
+        }
+
+        private void ValidateSemanticColors()
+        {
+            foreach (var entry in _semantic)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Value) || !_palette.TryGet(entry.Value, out _))
+                    throw new InvalidOperationException("Unknown palette color name '" + entry.Value + "' for semantic role '" + entry.Key + "'.");
             }
         }
 
-        return false;
-    }
+        private void ValidateMappings()
+        {
+            if (_ui.Mappings == null)
+                return;
 
-    private bool TryGetWildcardMapping(string projectName, out string key, out object value)
-    {
-        key = null;
-        value = null;
-        if (_ui.Mappings == null)
+            foreach (var entry in _ui.Mappings)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Key))
+                    throw new InvalidOperationException("Mapping keys cannot be empty.");
+
+                ValidateMappingValue(entry.Key, entry.Value);
+            }
+        }
+
+        private void ValidateMappingValue(string key, object value)
+        {
+            var text = value as string;
+            if (text != null)
+            {
+                text = text.Trim();
+                if (LooksLikeHex(text) && !IsHex(text))
+                    throw new InvalidOperationException("Invalid hex value '" + text + "' for mapping '" + key + "'. Expected #RRGGBB.");
+
+                if (IsHex(text))
+                    return;
+
+                if (!_palette.TryGet(text, out _))
+                    throw new InvalidOperationException("Unknown palette color name '" + text + "' for mapping '" + key + "'.");
+
+                return;
+            }
+
+            var values = ToStringObjectDictionary(value);
+            if (values == null)
+                throw new InvalidOperationException("Invalid mapping value type for mapping '" + key + "'. Use a palette name, hex value, or style object.");
+
+            foreach (var entry in values)
+            {
+                if (!string.Equals(entry.Key, "fill", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(entry.Key, "stroke", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(entry.Key, "color", StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException("Invalid or unsupported style field '" + entry.Key + "'. Allowed fields are fill, stroke, and color.");
+
+                var fieldValue = entry.Value as string;
+                if (fieldValue == null || !IsHex(fieldValue.Trim()))
+                    throw new InvalidOperationException("Invalid hex value for style field '" + entry.Key + "' in mapping '" + key + "'. Expected #RRGGBB.");
+            }
+        }
+
+        private bool TryGetExactMapping(string projectName, out string key, out object value)
+        {
+            key = null;
+            value = null;
+            if (_ui.Mappings == null)
+                return false;
+
+            foreach (var entry in _ui.Mappings)
+            {
+                if (entry.Key.IndexOf('*') >= 0)
+                    continue;
+
+                if (string.Equals(entry.Key, projectName, StringComparison.Ordinal))
+                {
+                    key = entry.Key;
+                    value = entry.Value;
+                    return true;
+                }
+            }
+
             return false;
+        }
 
-        var match = _ui.Mappings
-            .Where(entry => entry.Key.IndexOf('*') >= 0 && WildcardMatches(entry.Key, projectName))
-            .OrderByDescending(entry => Specificity(entry.Key))
-            .ThenBy(entry => entry.Key, StringComparer.Ordinal)
-            .FirstOrDefault();
+        private bool TryGetWildcardMapping(string projectName, out string key, out object value)
+        {
+            key = null;
+            value = null;
+            if (_ui.Mappings == null)
+                return false;
 
-        if (match.Key == null)
-            return false;
+            var match = _ui.Mappings
+                .Where(entry => entry.Key.IndexOf('*') >= 0 && WildcardMatches(entry.Key, projectName))
+                .OrderByDescending(entry => Specificity(entry.Key))
+                .ThenBy(entry => entry.Key, StringComparer.Ordinal)
+                .FirstOrDefault();
 
-        key = match.Key;
-        value = match.Value;
-        return true;
-    }
+            if (match.Key == null)
+                return false;
 
-    private string DetectRole(string projectName)
-    {
-        var roles = new List<KeyValuePair<string, string[]>>
+            key = match.Key;
+            value = match.Value;
+            return true;
+        }
+
+        private string DetectRole(string projectName)
+        {
+            var roles = new List<KeyValuePair<string, string[]>>
         {
             new KeyValuePair<string, string[]>("tests", new[] { "Tests", "Test", "Spec", "Specs" }),
             new KeyValuePair<string, string[]>("presentation", new[] { "Api", "Web", "MinimalApi", "Host", "Gateway" }),
@@ -237,126 +237,126 @@ public sealed class MermaidNodeStyleResolver
             new KeyValuePair<string, string[]>("tooling", new[] { "Seeder", "Migrator", "Tools", "Tool", "CLI", "Console" })
         };
 
-        var segments = SplitSegments(projectName);
-        foreach (var role in roles)
-        {
-            if (role.Value.Any(term => segments.Any(segment => string.Equals(segment, term, StringComparison.OrdinalIgnoreCase))))
-                return role.Key;
-        }
-
-        foreach (var role in roles)
-        {
-            if (role.Value.Any(term => projectName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0))
-                return role.Key;
-        }
-
-        return null;
-    }
-
-    private static IEnumerable<string> SplitSegments(string projectName)
-    {
-        return projectName.Split(new[] { '.', '-', '_', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-    }
-
-    private MermaidNodeStyle ResolveFallback(string projectName)
-    {
-        return _palette.Get(FallbackColorName(projectName));
-    }
-
-    private string FallbackColorName(string projectName)
-    {
-        var hash = StableHash(projectName ?? string.Empty);
-        return FallbackColorOrder[hash % FallbackColorOrder.Length];
-    }
-
-    private static int StableHash(string value)
-    {
-        unchecked
-        {
-            var hash = 2166136261u;
-            foreach (var ch in value.ToUpperInvariant())
+            var segments = SplitSegments(projectName);
+            foreach (var role in roles)
             {
-                hash ^= ch;
-                hash *= 16777619;
+                if (role.Value.Any(term => segments.Any(segment => string.Equals(segment, term, StringComparison.OrdinalIgnoreCase))))
+                    return role.Key;
             }
 
-            return (int)(hash & 0x7fffffff);
+            foreach (var role in roles)
+            {
+                if (role.Value.Any(term => projectName.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0))
+                    return role.Key;
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<string> SplitSegments(string projectName)
+        {
+            return projectName.Split(new[] { '.', '-', '_', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private MermaidNodeStyle ResolveFallback(string projectName)
+        {
+            return _palette.Get(FallbackColorName(projectName));
+        }
+
+        private string FallbackColorName(string projectName)
+        {
+            var hash = StableHash(projectName ?? string.Empty);
+            return FallbackColorOrder[hash % FallbackColorOrder.Length];
+        }
+
+        private static int StableHash(string value)
+        {
+            unchecked
+            {
+                var hash = 2166136261u;
+                foreach (var ch in value.ToUpperInvariant())
+                {
+                    hash ^= ch;
+                    hash *= 16777619;
+                }
+
+                return (int)(hash & 0x7fffffff);
+            }
+        }
+
+        private static bool WildcardMatches(string pattern, string value)
+        {
+            var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
+            return Regex.IsMatch(value, regex, RegexOptions.CultureInvariant);
+        }
+
+        private static int Specificity(string pattern)
+        {
+            return pattern.Count(ch => ch != '*');
+        }
+
+        private static bool LooksLikeHex(string value)
+        {
+            return value != null && value.StartsWith("#", StringComparison.Ordinal);
+        }
+
+        private static bool IsHex(string value)
+        {
+            return value != null && HexRegex.IsMatch(value);
+        }
+
+        private static string NormalizeHex(string value)
+        {
+            return value.Trim().ToUpperInvariant();
+        }
+
+        private static Dictionary<string, object> ToStringObjectDictionary(object value)
+        {
+            var typed = value as Dictionary<string, object>;
+            if (typed != null)
+                return typed;
+
+            var dictionary = value as IDictionary;
+            if (dictionary == null)
+                return null;
+
+            var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            foreach (DictionaryEntry entry in dictionary)
+                result[Convert.ToString(entry.Key, CultureInfo.InvariantCulture)] = entry.Value;
+
+            return result;
+        }
+
+        private static MermaidNodeStyle AutoStyle(string fill)
+        {
+            var readable = IsLight(fill) ? "#000000" : "#FFFFFF";
+            var stroke = readable;
+            return new MermaidNodeStyle(fill, stroke, readable);
+        }
+
+        private static bool IsLight(string hex)
+        {
+            var r = int.Parse(hex.Substring(1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var g = int.Parse(hex.Substring(3, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var b = int.Parse(hex.Substring(5, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var luminance = (0.299 * r) + (0.587 * g) + (0.114 * b);
+            return luminance > 186;
         }
     }
 
-    private static bool WildcardMatches(string pattern, string value)
+    public sealed class MermaidNodeResolvedStyle
     {
-        var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*") + "$";
-        return Regex.IsMatch(value, regex, RegexOptions.CultureInvariant);
+        public MermaidNodeResolvedStyle(MermaidNodeStyle style, string baseName, bool custom)
+        {
+            Style = style;
+            BaseName = baseName;
+            Custom = custom;
+        }
+
+        public MermaidNodeStyle Style { get; private set; }
+
+        public string BaseName { get; private set; }
+
+        public bool Custom { get; private set; }
     }
-
-    private static int Specificity(string pattern)
-    {
-        return pattern.Count(ch => ch != '*');
-    }
-
-    private static bool LooksLikeHex(string value)
-    {
-        return value != null && value.StartsWith("#", StringComparison.Ordinal);
-    }
-
-    private static bool IsHex(string value)
-    {
-        return value != null && HexRegex.IsMatch(value);
-    }
-
-    private static string NormalizeHex(string value)
-    {
-        return value.Trim().ToUpperInvariant();
-    }
-
-    private static Dictionary<string, object> ToStringObjectDictionary(object value)
-    {
-        var typed = value as Dictionary<string, object>;
-        if (typed != null)
-            return typed;
-
-        var dictionary = value as IDictionary;
-        if (dictionary == null)
-            return null;
-
-        var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-        foreach (DictionaryEntry entry in dictionary)
-            result[Convert.ToString(entry.Key, CultureInfo.InvariantCulture)] = entry.Value;
-
-        return result;
-    }
-
-    private static MermaidNodeStyle AutoStyle(string fill)
-    {
-        var readable = IsLight(fill) ? "#000000" : "#FFFFFF";
-        var stroke = readable;
-        return new MermaidNodeStyle(fill, stroke, readable);
-    }
-
-    private static bool IsLight(string hex)
-    {
-        var r = int.Parse(hex.Substring(1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-        var g = int.Parse(hex.Substring(3, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-        var b = int.Parse(hex.Substring(5, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-        var luminance = (0.299 * r) + (0.587 * g) + (0.114 * b);
-        return luminance > 186;
-    }
-}
-
-public sealed class MermaidNodeResolvedStyle
-{
-    public MermaidNodeResolvedStyle(MermaidNodeStyle style, string baseName, bool custom)
-    {
-        Style = style;
-        BaseName = baseName;
-        Custom = custom;
-    }
-
-    public MermaidNodeStyle Style { get; private set; }
-
-    public string BaseName { get; private set; }
-
-    public bool Custom { get; private set; }
-}
 }

--- a/src/SlnxMermaid.Core/Emit/MermaidPalette.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidPalette.cs
@@ -4,16 +4,16 @@ using System.Linq;
 
 namespace SlnxMermaid.Core.Emit
 {
-public sealed class MermaidPalette
-{
-    private readonly Dictionary<string, MermaidNodeStyle> _styles;
-
-    private MermaidPalette(Dictionary<string, MermaidNodeStyle> styles)
+    public sealed class MermaidPalette
     {
-        _styles = styles;
-    }
+        private readonly Dictionary<string, MermaidNodeStyle> _styles;
 
-    public static MermaidPalette DarkModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
+        private MermaidPalette(Dictionary<string, MermaidNodeStyle> styles)
+        {
+            _styles = styles;
+        }
+
+        public static MermaidPalette DarkModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
     {
         { "blue", new MermaidNodeStyle("#1565C0", "#90CAF9", "#FFFFFF") },
         { "green", new MermaidNodeStyle("#2E7D32", "#A5D6A7", "#FFFFFF") },
@@ -25,7 +25,7 @@ public sealed class MermaidPalette
         { "red", new MermaidNodeStyle("#B71C1C", "#EF9A9A", "#FFFFFF") }
     });
 
-    public static MermaidPalette LightModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
+        public static MermaidPalette LightModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
     {
         { "blue", new MermaidNodeStyle("#E3F2FD", "#1976D2", "#000000") },
         { "green", new MermaidNodeStyle("#E8F5E9", "#388E3C", "#000000") },
@@ -37,36 +37,36 @@ public sealed class MermaidPalette
         { "red", new MermaidNodeStyle("#FFEBEE", "#D32F2F", "#000000") }
     });
 
-    public IEnumerable<string> Names
-    {
-        get { return _styles.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase); }
+        public IEnumerable<string> Names
+        {
+            get { return _styles.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase); }
+        }
+
+        public bool TryGet(string name, out MermaidNodeStyle style)
+        {
+            return _styles.TryGetValue(name, out style);
+        }
+
+        public MermaidNodeStyle Get(string name)
+        {
+            MermaidNodeStyle style;
+            if (!TryGet(name, out style))
+                throw new InvalidOperationException("Unknown palette color name '" + name + "'.");
+
+            return style;
+        }
+
+        public static MermaidPalette ForMode(string mode)
+        {
+            var normalizedMode = string.IsNullOrWhiteSpace(mode) ? "dark" : mode.Trim();
+
+            if (string.Equals(normalizedMode, "dark", StringComparison.OrdinalIgnoreCase))
+                return DarkModePalette;
+
+            if (string.Equals(normalizedMode, "light", StringComparison.OrdinalIgnoreCase))
+                return LightModePalette;
+
+            throw new InvalidOperationException("Unknown ui.mode '" + mode + "'. Supported values are 'dark' and 'light'.");
+        }
     }
-
-    public bool TryGet(string name, out MermaidNodeStyle style)
-    {
-        return _styles.TryGetValue(name, out style);
-    }
-
-    public MermaidNodeStyle Get(string name)
-    {
-        MermaidNodeStyle style;
-        if (!TryGet(name, out style))
-            throw new InvalidOperationException("Unknown palette color name '" + name + "'.");
-
-        return style;
-    }
-
-    public static MermaidPalette ForMode(string mode)
-    {
-        var normalizedMode = string.IsNullOrWhiteSpace(mode) ? "dark" : mode.Trim();
-
-        if (string.Equals(normalizedMode, "dark", StringComparison.OrdinalIgnoreCase))
-            return DarkModePalette;
-
-        if (string.Equals(normalizedMode, "light", StringComparison.OrdinalIgnoreCase))
-            return LightModePalette;
-
-        throw new InvalidOperationException("Unknown ui.mode '" + mode + "'. Supported values are 'dark' and 'light'.");
-    }
-}
 }

--- a/src/SlnxMermaid.Core/Extensions/MarkdownTextExtensions.cs
+++ b/src/SlnxMermaid.Core/Extensions/MarkdownTextExtensions.cs
@@ -2,19 +2,19 @@
 
 namespace SlnxMermaid.Core.Extensions
 {
-public static class MarkdownTextExtensions 
-{
-    public static string WrapCodeForMarkdown(this string mermaid)
+    public static class MarkdownTextExtensions
     {
-        return WrapCodeForMarkdown(mermaid, "mermaid");
-    }
+        public static string WrapCodeForMarkdown(this string mermaid)
+        {
+            return WrapCodeForMarkdown(mermaid, "mermaid");
+        }
 
-    public static string WrapCodeForMarkdown(this string mermaid, string mdCodeLang)
-    {
-        return
-            $"```{mdCodeLang}{Environment.NewLine}" +
-            $"{mermaid}{Environment.NewLine}" +
-            $"```";
+        public static string WrapCodeForMarkdown(this string mermaid, string mdCodeLang)
+        {
+            return
+                $"```{mdCodeLang}{Environment.NewLine}" +
+                $"{mermaid}{Environment.NewLine}" +
+                $"```";
+        }
     }
-}
 }

--- a/src/SlnxMermaid.Core/Extensions/SlnxMermaidConfigExtensions.cs
+++ b/src/SlnxMermaid.Core/Extensions/SlnxMermaidConfigExtensions.cs
@@ -5,39 +5,39 @@ using SlnxMermaid.Core.Exceptions;
 
 namespace SlnxMermaid.Core.Extensions
 {
-public static class SlnxMermaidConfigExtensions
-{
-    public static SlnxMermaidConfig Validate(this SlnxMermaidConfig config)
+    public static class SlnxMermaidConfigExtensions
     {
-        if (!File.Exists(config.Solution))
-            throw new SolutionNotFoundException(config.Solution);
-
-        return config;
-    }
-
-    public static SlnxMermaidConfig Normalize(this SlnxMermaidConfig config, string configPath)
-    {
-        if (config == null)
-            throw new ArgumentNullException(nameof(config));
-
-        var baseDir = configPath.ResolveBaseDirectory();
-
-        if (!string.IsNullOrWhiteSpace(config.Solution))
-            config.Solution = config.Solution.ToAbsolute(baseDir);
-
-        if (config.Output != null && !string.IsNullOrWhiteSpace(config.Output.File))
-            config.Output.File = config.Output.File.ToAbsolute(baseDir);
-
-        var file = config.Output != null ? config.Output.File : null;
-
-        if (file != null && file.Contains("{date}"))
+        public static SlnxMermaidConfig Validate(this SlnxMermaidConfig config)
         {
-            config.Output.File = file.Replace(
-                "{date}",
-                DateTime.Now.ToString("yyyy-MM-dd HH_mm_ss"));
+            if (!File.Exists(config.Solution))
+                throw new SolutionNotFoundException(config.Solution);
+
+            return config;
         }
 
-        return config;
+        public static SlnxMermaidConfig Normalize(this SlnxMermaidConfig config, string configPath)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            var baseDir = configPath.ResolveBaseDirectory();
+
+            if (!string.IsNullOrWhiteSpace(config.Solution))
+                config.Solution = config.Solution.ToAbsolute(baseDir);
+
+            if (config.Output != null && !string.IsNullOrWhiteSpace(config.Output.File))
+                config.Output.File = config.Output.File.ToAbsolute(baseDir);
+
+            var file = config.Output != null ? config.Output.File : null;
+
+            if (file != null && file.Contains("{date}"))
+            {
+                config.Output.File = file.Replace(
+                    "{date}",
+                    DateTime.Now.ToString("yyyy-MM-dd HH_mm_ss"));
+            }
+
+            return config;
+        }
     }
-}
 }

--- a/src/SlnxMermaid.Core/Filtering/ProjectFilter.cs
+++ b/src/SlnxMermaid.Core/Filtering/ProjectFilter.cs
@@ -4,25 +4,25 @@ using System.Linq;
 
 namespace SlnxMermaid.Core.Filtering
 {
-public sealed class ProjectFilter
-{
-    private readonly string[] _excluded;
-
-    public ProjectFilter(IEnumerable<string> excluded)
+    public sealed class ProjectFilter
     {
-        _excluded = excluded?
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .ToArray();
-    }
+        private readonly string[] _excluded;
 
-    public bool IsAllowed(string projectId)
-    {
-        if (_excluded == null)
+        public ProjectFilter(IEnumerable<string> excluded)
         {
-            return true;
+            _excluded = excluded?
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .ToArray();
         }
 
-        return  _excluded.All(x => projectId.IndexOf(x, StringComparison.OrdinalIgnoreCase) < 0);
+        public bool IsAllowed(string projectId)
+        {
+            if (_excluded == null)
+            {
+                return true;
+            }
+
+            return _excluded.All(x => projectId.IndexOf(x, StringComparison.OrdinalIgnoreCase) < 0);
+        }
     }
-}
 }

--- a/src/SlnxMermaid.Core/Graph/ProjectNode.cs
+++ b/src/SlnxMermaid.Core/Graph/ProjectNode.cs
@@ -2,16 +2,16 @@
 
 namespace SlnxMermaid.Core.Graph
 {
-public sealed class ProjectNode
-{
-    public string Id { get; }
-    public string Path { get; }
-    public HashSet<ProjectNode> Dependencies { get; } = new HashSet<ProjectNode>();
-
-    public ProjectNode(string id, string path)
+    public sealed class ProjectNode
     {
-        Id = id;
-        Path = path;
+        public string Id { get; }
+        public string Path { get; }
+        public HashSet<ProjectNode> Dependencies { get; } = new HashSet<ProjectNode>();
+
+        public ProjectNode(string id, string path)
+        {
+            Id = id;
+            Path = path;
+        }
     }
-}
 }

--- a/src/SlnxMermaid.Core/Naming/NameTransformer.cs
+++ b/src/SlnxMermaid.Core/Naming/NameTransformer.cs
@@ -5,38 +5,38 @@ using System.Collections.Generic;
 
 namespace SlnxMermaid.Core.Naming
 {
-public sealed class NameTransformer
-{
-    private readonly string _stripPrefix;
-    private readonly Dictionary<string, string> _aliases;
-
-    public NameTransformer(NamingConfig namingConfig)
+    public sealed class NameTransformer
     {
-        _stripPrefix = namingConfig.StripPrefix.PrepareToDisplayOnMermaidDiagram();
-        _aliases = namingConfig.Aliases;
-    }
+        private readonly string _stripPrefix;
+        private readonly Dictionary<string, string> _aliases;
 
-    public string Transform(string rawName)
-    {
-        var name = NormalizeKnownAcronymCasing(rawName.PrepareToDisplayOnMermaidDiagram());
-
-        if (!string.IsNullOrEmpty(_stripPrefix) &&
-            name.StartsWith(_stripPrefix, StringComparison.Ordinal))
+        public NameTransformer(NamingConfig namingConfig)
         {
-            name = name.Substring(_stripPrefix.Length);
+            _stripPrefix = namingConfig.StripPrefix.PrepareToDisplayOnMermaidDiagram();
+            _aliases = namingConfig.Aliases;
         }
 
-        return _aliases != null && 
-               _aliases.TryGetValue(name, out var alias)
-                ? alias
-                : name;
-    }
+        public string Transform(string rawName)
+        {
+            var name = NormalizeKnownAcronymCasing(rawName.PrepareToDisplayOnMermaidDiagram());
 
-    private static string NormalizeKnownAcronymCasing(string name)
-    {
-        return string.IsNullOrEmpty(name)
-            ? name
-            : name.Replace("APi", "Api");
+            if (!string.IsNullOrEmpty(_stripPrefix) &&
+                name.StartsWith(_stripPrefix, StringComparison.Ordinal))
+            {
+                name = name.Substring(_stripPrefix.Length);
+            }
+
+            return _aliases != null &&
+                   _aliases.TryGetValue(name, out var alias)
+                    ? alias
+                    : name;
+        }
+
+        private static string NormalizeKnownAcronymCasing(string name)
+        {
+            return string.IsNullOrEmpty(name)
+                ? name
+                : name.Replace("APi", "Api");
+        }
     }
-}
 }

--- a/tests/SlnxMermaid.Gui.Avalonia.Tests/ConfigurationFormBuilderTests.cs
+++ b/tests/SlnxMermaid.Gui.Avalonia.Tests/ConfigurationFormBuilderTests.cs
@@ -12,7 +12,7 @@ public sealed class ConfigurationFormBuilderTests
         var config = new TestConfiguration();
         var fields = new ConfigurationFormBuilder().Build(config);
 
-        Assert.IsType<EnumFieldViewModel>(Assert.Single(fields.Where(field => field.Name == nameof(TestConfiguration.Mode))));
+        Assert.IsType<EnumFieldViewModel>(fields.Single(field => field.Name == nameof(TestConfiguration.Mode)));
     }
 
     [Fact]

--- a/tests/SlnxMermaid.UnitTests/Extensions/MermaidStringExtensionTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Extensions/MermaidStringExtensionTests.cs
@@ -9,7 +9,7 @@ namespace SlnxMermaid.UnitTests.Extensions
             [Theory]
             [InlineData(null, "")]
             [InlineData("", "")]
-            public void Returns_empty_for_null_or_empty(string input, string expected)
+            public void Returns_empty_for_null_or_empty(string? input, string expected)
             {
                 // act
                 var result = input.ConvertToAllowedMermaidString();
@@ -62,7 +62,7 @@ namespace SlnxMermaid.UnitTests.Extensions
             [InlineData(null)]
             [InlineData("")]
             [InlineData("   ")]
-            public void Returns_empty_for_null_or_whitespace_path(string input)
+            public void Returns_empty_for_null_or_whitespace_path(string? input)
             {
                 var result = input.PrepareToDisplayOnMermaidDiagram();
 


### PR DESCRIPTION
## Summary
- Add a reusable dotnet format workflow for the main solution.
- Wire the format check into the top-level CI workflow as a separate job.
- Apply dotnet format so the new verify-only check passes on the current codebase.

## Test Plan
- dotnet format SlnxMermaid.slnx --no-restore --verify-no-changes --verbosity minimal
- dotnet build SlnxMermaid.slnx --no-restore
- git diff --check
- Parsed .github/workflows/CI.yml and .github/workflows/CI-dotnet-format.yml with PyYAML