### PR TITLE
ci: polish merge guard PR comment

### DIFF
--- a/.github/workflows/CI-branch-merge-guard.yml
+++ b/.github/workflows/CI-branch-merge-guard.yml
@@ -7,8 +7,9 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: read
+      issues: write
+      pull-requests: read
 
     steps:
       - name: Enforce branch merge rules
@@ -23,11 +24,38 @@ jobs:
 
           fail() {
             local message="$1"
+            local marker='<!-- branch-merge-guard -->'
+            local existing_comment_id
+            local body
 
             echo "❌ $message"
 
-            gh api repos/$REPO/issues/$PR_NUMBER/comments \
-              -f body="🚫 **Merge blocked**\n\n$message"
+            body=$(printf '%s\n' \
+              "$marker" \
+              '## 🚫 Merge blocked' \
+              '' \
+              "This pull request targets **$BASE**, but its source branch **$HEAD** does not match the required naming rules." \
+              '' \
+              'Allowed source branch prefixes for **master**:' \
+              '' \
+              '- `feat/` — new features' \
+              '- `fix/` — bug fixes' \
+              '- `codex/` — Codex-generated changes' \
+              '' \
+              'Please rename or recreate the branch with one of the allowed prefixes, then update the pull request.')
+
+            existing_comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.user.type == "Bot" and (.body // "" | contains("<!-- branch-merge-guard -->"))) | .id' \
+              | head -n 1)
+
+            if [[ -n "$existing_comment_id" ]]; then
+              gh api "repos/$REPO/issues/comments/$existing_comment_id" \
+                --method PATCH \
+                -f body="$body"
+            else
+              gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+                -f body="$body"
+            fi
 
             exit 1
           }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,8 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
+      pull-requests: read
     uses: ./.github/workflows/CI-branch-merge-guard.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- Replaces the escaped one-line merge guard comment with a formatted Markdown message.
- Shows target/source branch context and the allowed branch prefixes as a readable list.
- Updates the existing merge-guard bot comment instead of posting duplicates on reruns.
- Narrows the workflow permissions to issue comments plus read-only PR access.

## Test Plan
- YAML parsed successfully for CI.yml and CI-branch-merge-guard.yml
- bash -n passed for the merge guard script
- git diff --check passed