### PR TITLE
ci: polish merge guard PR comment

### DIFF
--- a/.github/workflows/CI-branch-merge-guard.yml
+++ b/.github/workflows/CI-branch-merge-guard.yml
@@ -7,8 +7,9 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       contents: read
+      issues: write
+      pull-requests: read
 
     steps:
       - name: Enforce branch merge rules
@@ -23,11 +24,38 @@ jobs:
 
           fail() {
             local message="$1"
+            local marker='<!-- branch-merge-guard -->'
+            local existing_comment_id
+            local body
 
             echo "❌ $message"
 
-            gh api repos/$REPO/issues/$PR_NUMBER/comments \
-              -f body="🚫 **Merge blocked**\n\n$message"
+            body=$(printf '%s\n' \
+              "$marker" \
+              '## 🚫 Merge blocked' \
+              '' \
+              "This pull request targets **$BASE**, but its source branch **$HEAD** does not match the required naming rules." \
+              '' \
+              'Allowed source branch prefixes for **master**:' \
+              '' \
+              '- `feat/` — new features' \
+              '- `fix/` — bug fixes' \
+              '- `codex/` — Codex-generated changes' \
+              '' \
+              'Please rename or recreate the branch with one of the allowed prefixes, then update the pull request.')
+
+            existing_comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.user.type == "Bot" and (.body // "" | contains("<!-- branch-merge-guard -->"))) | .id' \
+              | head -n 1)
+
+            if [[ -n "$existing_comment_id" ]]; then
+              gh api "repos/$REPO/issues/comments/$existing_comment_id" \
+                --method PATCH \
+                -f body="$body"
+            else
+              gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+                -f body="$body"
+            fi
 
             exit 1
           }

--- a/.github/workflows/CI-branch-merge-guard.yml
+++ b/.github/workflows/CI-branch-merge-guard.yml
@@ -38,7 +38,7 @@ jobs:
               '' \
               'Allowed source branch prefixes for **master**:' \
               '' \
-              '- `feat/` — new features' \
+              '- `feature/` — new features' \
               '- `fix/` — bug fixes' \
               '- `codex/` — Codex-generated changes' \
               '' \
@@ -65,10 +65,10 @@ jobs:
           case "$BASE" in
 
             master)
-              if [[ "$HEAD" =~ ^feat/.* || "$HEAD" =~ ^fix/.* || "$HEAD" =~ ^codex/.* ]]; then
+              if [[ "$HEAD" =~ ^feature/.* || "$HEAD" =~ ^fix/.* || "$HEAD" =~ ^codex/.* ]]; then
                 exit 0
               fi
-              fail "Into **master** allowed only from **feat/***, **fix/*** or **codex/***."
+              fail "Into **master** allowed only from **feature/***, **fix/*** or **codex/***."
               ;;
 
             *)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,8 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
+      pull-requests: read
     uses: ./.github/workflows/CI-branch-merge-guard.yml
     secrets: inherit
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ GitHub Actions workflows live in `.github/workflows/`. The main CI paths include
 
 Use concise imperative commit summaries, often followed by a PR number when GitHub adds one, such as `Harden MermaidEmitter validation and style output (#83)`. Keep commits focused on one behavior or documentation change. Pull requests should include a clear description, linked issue when applicable, test evidence, and screenshots or generated Mermaid output when UI, VSIX, or diagram rendering changes.
 
+When opening pull requests into `master`, use only these source branch prefixes: `feature/` for new features, `fix/` for bug fixes, and `codex/` for Codex-generated changes. Do not use `feat/`, `docs/`, `ci/`, or other prefixes for PRs targeting `master`, because the merge guard blocks them.
+
 ## Security & Configuration Tips
 
 Do not commit Marketplace tokens, Sonar tokens, NuGet API keys, local secrets, or user-specific IDE settings. Use `slnx-mermaid.yml` for sample configuration and keep generated output paths predictable and relative. When touching VSIX publication, remember Marketplace publishing depends on the `VS_MARKETPLACE_TOKEN` repository secret and should be run from the configured CD workflow on `master`.


### PR DESCRIPTION
## Summary
- Moves the merge guard update onto the required branch prefix: feature/prettier-merge-guard-comment.
- Replaces the escaped one-line merge guard comment with a formatted Markdown message.
- Updates existing merge-guard bot comments instead of posting duplicates on reruns.
- Aligns the merge guard with the branch naming rule: feature/, fix/, or codex/ into master.
- Documents the branch naming rule in AGENTS.md so future agents follow it.

## Test Plan
- YAML parsed successfully for CI.yml and CI-branch-merge-guard.yml
- bash -n passed for the merge guard script
- git diff --check passed