### PR TITLE
Add JSON Schema generation, VS Code YAML IntelliSense, and schema validation tests

### DIFF
--- a/.github/workflows/CI-build-linux-net10.yml
+++ b/.github/workflows/CI-build-linux-net10.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: dotnet build SlnxMermaid.slnx --no-restore
 
+      - name: Verify generated configuration schema is committed
+        run: git diff --exit-code -- schemas/slnx-mermaid.schema.json
+
       - name: Upload build outputs
         uses: actions/upload-artifact@v4
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "yaml.schemas": {
+    "./schemas/slnx-mermaid.schema.json": [
+      "slnx-mermaid.yml",
+      "slnx-mermaid.yaml"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ slnx-mermaid --config slnx-mermaid.yml
 
 The CLI reads the configured `.sln` or `.slnx`, analyzes project references, and writes a Markdown file containing a fenced Mermaid graph to `output.file`. Relative `solution` and `output.file` paths are resolved from the configuration file location.
 
+
+## YAML IntelliSense
+
+Install the Red Hat YAML extension for VS Code to enable JSON Schema-based assistance for `slnx-mermaid.yml`. The repository includes a JSON Schema at [`schemas/slnx-mermaid.schema.json`](schemas/slnx-mermaid.schema.json), and VS Code uses [`.vscode/settings.json`](.vscode/settings.json) to associate it with:
+
+- `slnx-mermaid.yml`
+- `slnx-mermaid.yaml`
+
+The schema provides autocomplete, validation, enum suggestions, defaults, and field descriptions for the supported configuration options. It is generated from the shared configuration model and its metadata; after changing the model, regenerate the checked-in schema with:
+
+```bash
+dotnet run --project tools/SlnxMermaid.SchemaGenerator
+```
+
+The configuration test suite verifies that the committed schema is identical to the generated output, so model and schema drift fails CI.
+
 ## Fast start (VSIX)
 
 1. Install the extension from Visual Studio Marketplace.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ Install the Red Hat YAML extension for VS Code to enable JSON Schema-based assis
 - `slnx-mermaid.yml`
 - `slnx-mermaid.yaml`
 
-The schema provides autocomplete, validation, enum suggestions, defaults, and field descriptions for the supported configuration options. It is generated from the shared configuration model and its metadata; after changing the model, regenerate the checked-in schema with:
+The schema provides autocomplete, validation, enum suggestions, defaults, and field descriptions for the supported configuration options. It is generated from the shared configuration model and its metadata.
+
+Building `SlnxMermaid.slnx` automatically regenerates the checked-in schema through the `SlnxMermaid.SchemaGenerator` project, so no separate regeneration command is needed during the normal workflow. To regenerate only the schema, run:
 
 ```bash
 dotnet run --project tools/SlnxMermaid.SchemaGenerator
 ```
 
-The configuration test suite verifies that the committed schema is identical to the generated output, so model and schema drift fails CI.
+Commit the regenerated schema together with model changes. CI verifies that a solution build leaves `schemas/slnx-mermaid.schema.json` unchanged, and the configuration test suite also compares it with generated output.
 
 ## Fast start (VSIX)
 

--- a/SlnxMermaid.slnx
+++ b/SlnxMermaid.slnx
@@ -6,4 +6,5 @@
   <Project Path="tests/SlnxMermaid.Configuration.Tests/SlnxMermaid.Configuration.Tests.csproj" />
   <Project Path="src/SlnxMermaid.Core/SlnxMermaid.Core.csproj" Id="d5badfcd-044d-4ead-b30a-699167eac31b" />
   <Project Path="tests/SlnxMermaid.UnitTests/SlnxMermaid.UnitTests.csproj" Id="b6bc326c-ac66-4d57-b144-8e7a66f968f8" />
+  <Project Path="tools/SlnxMermaid.SchemaGenerator/SlnxMermaid.SchemaGenerator.csproj" />
 </Solution>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,10 +154,12 @@ Forward slashes are recommended for cross-platform compatibility.
 
 ## JSON Schema generation
 
-`schemas/slnx-mermaid.schema.json` is generated from the shared configuration classes in `SlnxMermaid.Configuration` and their schema metadata attributes. Do not edit the generated JSON directly. After changing a configuration property, description, default, allowed value, or validation constraint, regenerate it with:
+`schemas/slnx-mermaid.schema.json` is generated from the shared configuration classes in `SlnxMermaid.Configuration` and their schema metadata attributes. Do not edit the generated JSON directly.
+
+A normal build of `SlnxMermaid.slnx` builds the `SlnxMermaid.SchemaGenerator` project and automatically regenerates the schema after that project is compiled. The generator writes the file only when its contents changed. To regenerate the schema without building the full solution, run:
 
 ```bash
 dotnet run --project tools/SlnxMermaid.SchemaGenerator
 ```
 
-Tests compare the generated output with the committed schema to prevent drift. The repository's `.vscode/settings.json` associates the generated schema with `slnx-mermaid.yml` and `slnx-mermaid.yaml`.
+Commit the regenerated schema together with configuration-model changes. CI builds the solution and then checks that the schema has no uncommitted diff; tests also compare the generated output with the committed file. The repository's `.vscode/settings.json` associates the generated schema with `slnx-mermaid.yml` and `slnx-mermaid.yaml`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,3 +151,13 @@ Both `solution` and `output.file` support:
 - absolute paths
 
 Forward slashes are recommended for cross-platform compatibility.
+
+## JSON Schema generation
+
+`schemas/slnx-mermaid.schema.json` is generated from the shared configuration classes in `SlnxMermaid.Configuration` and their schema metadata attributes. Do not edit the generated JSON directly. After changing a configuration property, description, default, allowed value, or validation constraint, regenerate it with:
+
+```bash
+dotnet run --project tools/SlnxMermaid.SchemaGenerator
+```
+
+Tests compare the generated output with the committed schema to prevent drift. The repository's `.vscode/settings.json` associates the generated schema with `slnx-mermaid.yml` and `slnx-mermaid.yaml`.

--- a/examples/slnx-mermaid.yml
+++ b/examples/slnx-mermaid.yml
@@ -1,0 +1,41 @@
+solution: ../SlnxMermaid.slnx
+
+diagram:
+  direction: LR
+  includeTransitiveDependencies: false
+  orderDependenciesByDepth: true
+
+filters:
+  exclude:
+    - Tests
+    - AppHost
+    - ServiceDefaults
+    - Seeder
+
+ui:
+  mode: dark
+  semantic:
+    presentation: blue
+    application: green
+    domain: yellow
+    infrastructure: orange
+    dataAccess: pink
+    tooling: purple
+    tests: gray
+  mappings:
+    SlnxMermaid_CLI: purple
+    SlnxMermaid_Core:
+      fill: "#141414"
+      stroke: "#90CAF9"
+      color: "#FFFFFF"
+    "*Tests*": gray
+    "*Model*": "#37474F"
+
+naming:
+  stripPrefix: SlnxMermaid_
+  aliases:
+    Core: CORE
+    CLI: CommandLineInterface
+
+output:
+  file: ../docs/architecture/dependency-graph-mermaid.md

--- a/licenses/policy.yml
+++ b/licenses/policy.yml
@@ -52,3 +52,21 @@ exceptions:
     source: https://www.nuget.org/packages/Avalonia.Angle.Windows.Natives/2.1.27548.20260419/License
     rationale: "Avalonia desktop native dependency. NuGet publishes a license file matching BSD-3-Clause terms."
 
+  Json.More.Net:
+    version: "3.0.1"
+    license: "MIT"
+    source: https://github.com/json-everything/json-everything
+    rationale: "NuGet package uses OSMFEULA.txt for binary distribution, whose text states the project source is licensed under MIT. Approved for schema validation test dependency."
+
+  JsonPointer.Net:
+    version: "7.0.1"
+    license: "MIT"
+    source: https://github.com/json-everything/json-everything
+    rationale: "NuGet package uses OSMFEULA.txt for binary distribution, whose text states the project source is licensed under MIT. Approved as JsonSchema.Net dependency."
+
+  JsonSchema.Net:
+    version: "9.2.1"
+    license: "MIT"
+    source: https://github.com/json-everything/json-everything
+    rationale: "NuGet package uses OSMFEULA.txt for binary distribution, whose text states the project source is licensed under MIT. Approved for configuration schema validation tests."
+

--- a/schemas/slnx-mermaid.schema.json
+++ b/schemas/slnx-mermaid.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/asienicki/slnx-mermaid/master/schemas/slnx-mermaid.schema.json",
+  "title": "slnx-mermaid configuration",
+  "description": "Configuration for generating Mermaid dependency diagrams from .sln and .slnx files.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "solution": {
+      "description": "Path to the .sln or .slnx file to analyze. Relative paths are resolved from the configuration file location.",
+      "type": "string",
+      "minLength": 1
+    },
+    "diagram": {
+      "description": "Controls Mermaid graph generation behavior.",
+      "$ref": "#/$defs/DiagramConfig"
+    },
+    "filters": {
+      "description": "Filters that remove projects from the emitted dependency graph.",
+      "$ref": "#/$defs/FilterConfig"
+    },
+    "naming": {
+      "description": "Controls display names and Mermaid node ids after project file names are normalized.",
+      "$ref": "#/$defs/NamingConfig"
+    },
+    "output": {
+      "description": "Controls where generated Mermaid markdown is written.",
+      "$ref": "#/$defs/OutputConfig"
+    },
+    "ui": {
+      "description": "Controls color palette mode, semantic role colors, and per-project style overrides.",
+      "$ref": "#/$defs/UiConfig"
+    }
+  },
+  "required": [
+    "solution",
+    "output"
+  ],
+  "$defs": {
+    "DiagramConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "direction": {
+          "description": "Mermaid graph direction: top-down (TD), left-to-right (LR), bottom-to-top (BT), or right-to-left (RL).",
+          "type": "string",
+          "enum": [
+            "TD",
+            "LR",
+            "BT",
+            "RL"
+          ],
+          "default": "TD"
+        },
+        "includeTransitiveDependencies": {
+          "description": "When true, include both direct and indirect project dependencies. When false, include only direct project dependencies.",
+          "type": "boolean",
+          "default": false
+        },
+        "orderDependenciesByDepth": {
+          "description": "When true, order emitted dependencies by dependency depth. When false, use the legacy alphabetical edge order.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "FilterConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "exclude": {
+          "description": "Case-insensitive substrings matched against normalized project ids. Matching projects are excluded from nodes, edges, and styles.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      }
+    },
+    "NamingConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "stripPrefix": {
+          "description": "Prefix removed from normalized project ids before aliases are applied and labels are emitted.",
+          "type": "string"
+        },
+        "aliases": {
+          "description": "Maps transformed project names to explicit Mermaid node ids. Aliases are applied after normalization and stripPrefix.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      }
+    },
+    "OutputConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "description": "Target Markdown file path for the generated fenced Mermaid diagram. Relative paths are resolved from the configuration file location and may include supported path placeholders.",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "file"
+      ]
+    },
+    "UiConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "description": "Default Mermaid color palette mode used when resolving semantic and fallback styles.",
+          "type": "string",
+          "enum": [
+            "dark",
+            "light"
+          ],
+          "default": "dark"
+        },
+        "semantic": {
+          "description": "Overrides palette colors assigned to semantic project roles detected from normalized project ids.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "string",
+            "enum": [
+              "blue",
+              "green",
+              "yellow",
+              "orange",
+              "pink",
+              "purple",
+              "gray",
+              "red"
+            ]
+          },
+          "default": {}
+        },
+        "mappings": {
+          "description": "Per-project style overrides keyed by normalized project id. Keys may contain * wildcards and are case-sensitive.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "blue",
+                  "green",
+                  "yellow",
+                  "orange",
+                  "pink",
+                  "purple",
+                  "gray",
+                  "red"
+                ]
+              },
+              {
+                "type": "string",
+                "pattern": "^#[0-9a-fA-F]{6}$"
+              },
+              {
+                "$ref": "#/$defs/UiStyleConfig"
+              }
+            ]
+          },
+          "default": {}
+        }
+      }
+    },
+    "UiStyleConfig": {
+      "description": "Explicit Mermaid node style fields. Omitted fields inherit from the semantic or fallback base style when possible.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fill": {
+          "description": "Node fill color as #RRGGBB.",
+          "type": "string",
+          "pattern": "^#[0-9a-fA-F]{6}$"
+        },
+        "stroke": {
+          "description": "Node border color as #RRGGBB.",
+          "type": "string",
+          "pattern": "^#[0-9a-fA-F]{6}$"
+        },
+        "color": {
+          "description": "Node text color as #RRGGBB.",
+          "type": "string",
+          "pattern": "^#[0-9a-fA-F]{6}$"
+        }
+      }
+    }
+  },
+  "x-generated-by": "dotnet run --project tools/SlnxMermaid.SchemaGenerator"
+}

--- a/src/SlnxMermaid.Configuration/Config/ConfigurationDescriptionAttribute.cs
+++ b/src/SlnxMermaid.Configuration/Config/ConfigurationDescriptionAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace SlnxMermaid.Core.Config;
 
-[AttributeUsage(AttributeTargets.Property)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Property)]
 public sealed class ConfigurationDescriptionAttribute : Attribute
 {
     public ConfigurationDescriptionAttribute(string description) => Description = description;

--- a/src/SlnxMermaid.Configuration/Config/ConfigurationSchemaAttributes.cs
+++ b/src/SlnxMermaid.Configuration/Config/ConfigurationSchemaAttributes.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace SlnxMermaid.Core.Config;
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ConfigurationRequiredAttribute : Attribute
+{
+}
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ConfigurationAllowedValuesAttribute : Attribute
+{
+    public ConfigurationAllowedValuesAttribute(params string[] values) => Values = values;
+
+    public string[] Values { get; }
+}
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ConfigurationStringConstraintAttribute : Attribute
+{
+    public int MinLength { get; set; }
+
+    public string? Pattern { get; set; }
+}
+
+public enum ConfigurationDictionaryValueKind
+{
+    String,
+    PaletteColor,
+    ProjectStyle
+}
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ConfigurationDictionaryValueAttribute : Attribute
+{
+    public ConfigurationDictionaryValueAttribute(ConfigurationDictionaryValueKind kind) => Kind = kind;
+
+    public ConfigurationDictionaryValueKind Kind { get; }
+}

--- a/src/SlnxMermaid.Configuration/Config/ConfigurationSchemaGenerator.cs
+++ b/src/SlnxMermaid.Configuration/Config/ConfigurationSchemaGenerator.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace SlnxMermaid.Core.Config;
+
+public static class ConfigurationSchemaGenerator
+{
+    public const string SchemaId = "https://raw.githubusercontent.com/asienicki/slnx-mermaid/master/schemas/slnx-mermaid.schema.json";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public static string Generate()
+    {
+        var definitions = new JsonObject();
+        var root = BuildObjectSchema(typeof(SlnxMermaidConfig), definitions, includeDescription: true);
+
+        root.Insert(0, "$schema", "https://json-schema.org/draft/2020-12/schema");
+        root.Insert(1, "$id", SchemaId);
+        root.Insert(2, "title", "slnx-mermaid configuration");
+        root["$defs"] = definitions;
+        root["x-generated-by"] = "dotnet run --project tools/SlnxMermaid.SchemaGenerator";
+
+        return root.ToJsonString(SerializerOptions) + "\n";
+    }
+
+    private static JsonObject BuildObjectSchema(Type type, JsonObject definitions, bool includeDescription)
+    {
+        var schema = new JsonObject();
+        if (includeDescription && GetDescription(type) is { Length: > 0 } description)
+            schema["description"] = description;
+
+        schema["type"] = "object";
+        schema["additionalProperties"] = false;
+
+        var properties = new JsonObject();
+        var required = new JsonArray();
+        var defaults = Activator.CreateInstance(type);
+
+        foreach (var property in GetConfigurationProperties(type))
+        {
+            properties[ToCamelCase(property.Name)] = BuildPropertySchema(property, defaults, definitions);
+            if (property.GetCustomAttribute<ConfigurationRequiredAttribute>() != null)
+                required.Add(ToCamelCase(property.Name));
+        }
+
+        schema["properties"] = properties;
+        if (required.Count > 0)
+            schema["required"] = required;
+
+        return schema;
+    }
+
+    private static JsonObject BuildPropertySchema(PropertyInfo property, object? defaults, JsonObject definitions)
+    {
+        var type = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        JsonObject schema;
+
+        if (type == typeof(string))
+            schema = BuildStringSchema(property);
+        else if (type == typeof(bool))
+            schema = new JsonObject { ["type"] = "boolean" };
+        else if (type.IsEnum)
+            schema = new JsonObject
+            {
+                ["type"] = "string",
+                ["enum"] = BuildStringArray(Enum.GetNames(type))
+            };
+        else if (IsInteger(type))
+            schema = new JsonObject { ["type"] = "integer" };
+        else if (IsNumber(type))
+            schema = new JsonObject { ["type"] = "number" };
+        else if (IsDictionary(type))
+            schema = BuildDictionarySchema(property, definitions);
+        else if (IsList(type))
+            schema = BuildListSchema(type);
+        else
+            schema = BuildReferenceSchema(type, definitions);
+
+        var description = GetDescription(property);
+        if (string.IsNullOrWhiteSpace(description))
+            throw new InvalidOperationException($"Configuration property '{property.DeclaringType?.Name}.{property.Name}' must have a description.");
+
+        schema.Insert(0, "description", description);
+        AddDefault(schema, property, defaults);
+        return schema;
+    }
+
+    private static JsonObject BuildStringSchema(PropertyInfo property)
+    {
+        var schema = new JsonObject { ["type"] = "string" };
+        var allowedValues = property.GetCustomAttribute<ConfigurationAllowedValuesAttribute>();
+        if (allowedValues != null)
+            schema["enum"] = BuildStringArray(allowedValues.Values);
+
+        var constraint = property.GetCustomAttribute<ConfigurationStringConstraintAttribute>();
+        if (constraint?.MinLength > 0)
+            schema["minLength"] = constraint.MinLength;
+        if (!string.IsNullOrWhiteSpace(constraint?.Pattern))
+            schema["pattern"] = constraint.Pattern;
+
+        return schema;
+    }
+
+    private static JsonObject BuildDictionarySchema(PropertyInfo property, JsonObject definitions)
+    {
+        var schema = new JsonObject
+        {
+            ["type"] = "object",
+            ["propertyNames"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["minLength"] = 1
+            }
+        };
+
+        var valueMetadata = property.GetCustomAttribute<ConfigurationDictionaryValueAttribute>()
+            ?? throw new InvalidOperationException($"Dictionary property '{property.DeclaringType?.Name}.{property.Name}' must declare its schema value kind.");
+        var kind = valueMetadata.Kind;
+        schema["additionalProperties"] = kind switch
+        {
+            ConfigurationDictionaryValueKind.PaletteColor => BuildPaletteColorSchema(),
+            ConfigurationDictionaryValueKind.ProjectStyle => BuildProjectStyleSchema(definitions),
+            _ => new JsonObject { ["type"] = "string" }
+        };
+
+        return schema;
+    }
+
+    private static JsonObject BuildProjectStyleSchema(JsonObject definitions)
+    {
+        EnsureDefinition(typeof(UiStyleConfig), definitions);
+        return new JsonObject
+        {
+            ["oneOf"] = new JsonArray
+            {
+                BuildPaletteColorSchema(),
+                BuildHexColorSchema(),
+                new JsonObject { ["$ref"] = $"#/$defs/{GetDefinitionName(typeof(UiStyleConfig))}" }
+            }
+        };
+    }
+
+    private static JsonObject BuildPaletteColorSchema() => new()
+    {
+        ["type"] = "string",
+        ["enum"] = BuildStringArray(UiPalette.Names)
+    };
+
+    private static JsonObject BuildHexColorSchema() => new()
+    {
+        ["type"] = "string",
+        ["pattern"] = "^#[0-9a-fA-F]{6}$"
+    };
+
+    private static JsonArray BuildStringArray(IEnumerable<string> values)
+    {
+        var result = new JsonArray();
+        foreach (var value in values)
+            result.Add(value);
+
+        return result;
+    }
+
+    private static JsonObject BuildListSchema(Type type)
+    {
+        var itemType = type.IsGenericType ? type.GetGenericArguments()[0] : typeof(object);
+        return new JsonObject
+        {
+            ["type"] = "array",
+            ["items"] = itemType == typeof(string)
+                ? new JsonObject { ["type"] = "string" }
+                : new JsonObject { ["type"] = "object" }
+        };
+    }
+
+    private static JsonObject BuildReferenceSchema(Type type, JsonObject definitions)
+    {
+        EnsureDefinition(type, definitions);
+        return new JsonObject { ["$ref"] = $"#/$defs/{GetDefinitionName(type)}" };
+    }
+
+    private static void EnsureDefinition(Type type, JsonObject definitions)
+    {
+        var name = GetDefinitionName(type);
+        if (definitions.ContainsKey(name))
+            return;
+
+        definitions[name] = null;
+        definitions[name] = BuildObjectSchema(type, definitions, includeDescription: true);
+    }
+
+    private static void AddDefault(JsonObject schema, PropertyInfo property, object? defaults)
+    {
+        var value = defaults == null ? null : property.GetValue(defaults);
+        if (value == null || IsConfigurationObject(value.GetType()))
+            return;
+
+        schema["default"] = JsonSerializer.SerializeToNode(value);
+    }
+
+    private static IEnumerable<PropertyInfo> GetConfigurationProperties(Type type) => type
+        .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+        .Where(property => property.CanRead && property.CanWrite && property.GetIndexParameters().Length == 0)
+        .OrderBy(property => property.MetadataToken);
+
+    private static bool IsDictionary(Type type) => typeof(IDictionary).IsAssignableFrom(type);
+
+    private static bool IsList(Type type) => typeof(IList).IsAssignableFrom(type);
+
+    private static bool IsInteger(Type type) => type == typeof(byte)
+        || type == typeof(sbyte)
+        || type == typeof(short)
+        || type == typeof(ushort)
+        || type == typeof(int)
+        || type == typeof(uint)
+        || type == typeof(long)
+        || type == typeof(ulong);
+
+    private static bool IsNumber(Type type) => type == typeof(float)
+        || type == typeof(double)
+        || type == typeof(decimal);
+
+    private static bool IsConfigurationObject(Type type) => type.Namespace == typeof(SlnxMermaidConfig).Namespace
+        && !IsDictionary(type)
+        && !IsList(type);
+
+    private static string GetDefinitionName(Type type) => type.Name;
+
+    private static string? GetDescription(MemberInfo member) => member
+        .GetCustomAttribute<ConfigurationDescriptionAttribute>()?.Description;
+
+    private static string ToCamelCase(string value) => string.IsNullOrEmpty(value)
+        ? value
+        : char.ToLowerInvariant(value[0]) + value.Substring(1);
+}

--- a/src/SlnxMermaid.Configuration/Config/DiagramConfig.cs
+++ b/src/SlnxMermaid.Configuration/Config/DiagramConfig.cs
@@ -2,9 +2,13 @@ namespace SlnxMermaid.Core.Config;
 
 public sealed class DiagramConfig
 {
+    [ConfigurationDescription("Mermaid graph direction: top-down (TD), left-to-right (LR), bottom-to-top (BT), or right-to-left (RL).")]
+    [ConfigurationAllowedValues("TD", "LR", "BT", "RL")]
     public string? Direction { get; set; } = "TD";
 
+    [ConfigurationDescription("When true, include both direct and indirect project dependencies. When false, include only direct project dependencies.")]
     public bool IncludeTransitiveDependencies { get; set; } = false;
 
+    [ConfigurationDescription("When true, order emitted dependencies by dependency depth. When false, use the legacy alphabetical edge order.")]
     public bool OrderDependenciesByDepth { get; set; } = true;
 }

--- a/src/SlnxMermaid.Configuration/Config/FilterConfig.cs
+++ b/src/SlnxMermaid.Configuration/Config/FilterConfig.cs
@@ -4,5 +4,6 @@ namespace SlnxMermaid.Core.Config;
 
 public sealed class FilterConfig
 {
+    [ConfigurationDescription("Case-insensitive substrings matched against normalized project ids. Matching projects are excluded from nodes, edges, and styles.")]
     public List<string> Exclude { get; set; } = new();
 }

--- a/src/SlnxMermaid.Configuration/Config/NamingConfig.cs
+++ b/src/SlnxMermaid.Configuration/Config/NamingConfig.cs
@@ -4,7 +4,10 @@ namespace SlnxMermaid.Core.Config;
 
 public sealed class NamingConfig
 {
+    [ConfigurationDescription("Prefix removed from normalized project ids before aliases are applied and labels are emitted.")]
     public string? StripPrefix { get; set; }
 
+    [ConfigurationDescription("Maps transformed project names to explicit Mermaid node ids. Aliases are applied after normalization and stripPrefix.")]
+    [ConfigurationDictionaryValue(ConfigurationDictionaryValueKind.String)]
     public Dictionary<string, string> Aliases { get; set; } = new();
 }

--- a/src/SlnxMermaid.Configuration/Config/OutputConfig.cs
+++ b/src/SlnxMermaid.Configuration/Config/OutputConfig.cs
@@ -2,5 +2,8 @@ namespace SlnxMermaid.Core.Config;
 
 public sealed class OutputConfig
 {
+    [ConfigurationDescription("Target Markdown file path for the generated fenced Mermaid diagram. Relative paths are resolved from the configuration file location and may include supported path placeholders.")]
+    [ConfigurationRequired]
+    [ConfigurationStringConstraint(MinLength = 1)]
     public string? File { get; set; }
 }

--- a/src/SlnxMermaid.Configuration/Config/SlnxMermaidConfig.cs
+++ b/src/SlnxMermaid.Configuration/Config/SlnxMermaidConfig.cs
@@ -1,16 +1,26 @@
 namespace SlnxMermaid.Core.Config;
 
+[ConfigurationDescription("Configuration for generating Mermaid dependency diagrams from .sln and .slnx files.")]
 public sealed class SlnxMermaidConfig
 {
+    [ConfigurationDescription("Path to the .sln or .slnx file to analyze. Relative paths are resolved from the configuration file location.")]
+    [ConfigurationRequired]
+    [ConfigurationStringConstraint(MinLength = 1)]
     public string? Solution { get; set; }
 
+    [ConfigurationDescription("Controls Mermaid graph generation behavior.")]
     public DiagramConfig? Diagram { get; set; } = new();
 
+    [ConfigurationDescription("Filters that remove projects from the emitted dependency graph.")]
     public FilterConfig? Filters { get; set; } = new();
 
+    [ConfigurationDescription("Controls display names and Mermaid node ids after project file names are normalized.")]
     public NamingConfig? Naming { get; set; } = new();
 
+    [ConfigurationDescription("Controls where generated Mermaid markdown is written.")]
+    [ConfigurationRequired]
     public OutputConfig? Output { get; set; } = new();
 
+    [ConfigurationDescription("Controls color palette mode, semantic role colors, and per-project style overrides.")]
     public UiConfig? Ui { get; set; } = new();
 }

--- a/src/SlnxMermaid.Configuration/Config/UiConfig.cs
+++ b/src/SlnxMermaid.Configuration/Config/UiConfig.cs
@@ -5,10 +5,15 @@ namespace SlnxMermaid.Core.Config;
 public sealed class UiConfig
 {
     [ConfigurationDisplayName("UI mode")]
-    [ConfigurationDescription("Controls default color palette mode. Supported values are dark and light.")]
+    [ConfigurationDescription("Default Mermaid color palette mode used when resolving semantic and fallback styles.")]
+    [ConfigurationAllowedValues("dark", "light")]
     public string? Mode { get; set; } = "dark";
 
+    [ConfigurationDescription("Overrides palette colors assigned to semantic project roles detected from normalized project ids.")]
+    [ConfigurationDictionaryValue(ConfigurationDictionaryValueKind.PaletteColor)]
     public Dictionary<string, string>? Semantic { get; set; } = new();
 
+    [ConfigurationDescription("Per-project style overrides keyed by normalized project id. Keys may contain * wildcards and are case-sensitive.")]
+    [ConfigurationDictionaryValue(ConfigurationDictionaryValueKind.ProjectStyle)]
     public Dictionary<string, object>? Mappings { get; set; } = new();
 }

--- a/src/SlnxMermaid.Configuration/Config/UiPalette.cs
+++ b/src/SlnxMermaid.Configuration/Config/UiPalette.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace SlnxMermaid.Core.Config;
+
+public static class UiPalette
+{
+    public const string Blue = "blue";
+    public const string Green = "green";
+    public const string Yellow = "yellow";
+    public const string Orange = "orange";
+    public const string Pink = "pink";
+    public const string Purple = "purple";
+    public const string Gray = "gray";
+    public const string Red = "red";
+
+    public static IReadOnlyList<string> Names { get; } = new[]
+    {
+        Blue,
+        Green,
+        Yellow,
+        Orange,
+        Pink,
+        Purple,
+        Gray,
+        Red
+    };
+}

--- a/src/SlnxMermaid.Configuration/Config/UiStyleConfig.cs
+++ b/src/SlnxMermaid.Configuration/Config/UiStyleConfig.cs
@@ -1,0 +1,17 @@
+namespace SlnxMermaid.Core.Config;
+
+[ConfigurationDescription("Explicit Mermaid node style fields. Omitted fields inherit from the semantic or fallback base style when possible.")]
+public sealed class UiStyleConfig
+{
+    [ConfigurationDescription("Node fill color as #RRGGBB.")]
+    [ConfigurationStringConstraint(Pattern = "^#[0-9a-fA-F]{6}$")]
+    public string? Fill { get; set; }
+
+    [ConfigurationDescription("Node border color as #RRGGBB.")]
+    [ConfigurationStringConstraint(Pattern = "^#[0-9a-fA-F]{6}$")]
+    public string? Stroke { get; set; }
+
+    [ConfigurationDescription("Node text color as #RRGGBB.")]
+    [ConfigurationStringConstraint(Pattern = "^#[0-9a-fA-F]{6}$")]
+    public string? Color { get; set; }
+}

--- a/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidNodeStyleResolver.cs
@@ -15,7 +15,7 @@ namespace SlnxMermaid.Core.Emit
         private const string White = "#FFFFFF";
         private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
         private static readonly Regex HexRegex = new Regex("^#[0-9a-fA-F]{6}$", RegexOptions.Compiled, RegexTimeout);
-        private static readonly string[] FallbackColorOrder = { "blue", "green", "yellow", "orange", "pink", "purple", "gray", "red" };
+        private static readonly string[] FallbackColorOrder = UiPalette.Names.ToArray();
 
         private readonly UiConfig _ui;
         private readonly MermaidPalette _palette;
@@ -129,13 +129,13 @@ namespace SlnxMermaid.Core.Emit
         {
             var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            { "presentation", "blue" },
-            { "application", "green" },
-            { "domain", "yellow" },
-            { "infrastructure", "orange" },
-            { "dataaccess", "pink" },
-            { "tooling", "purple" },
-            { "tests", "gray" }
+            { "presentation", UiPalette.Blue },
+            { "application", UiPalette.Green },
+            { "domain", UiPalette.Yellow },
+            { "infrastructure", UiPalette.Orange },
+            { "dataaccess", UiPalette.Pink },
+            { "tooling", UiPalette.Purple },
+            { "tests", UiPalette.Gray }
         };
 
             if (configured != null)

--- a/src/SlnxMermaid.Core/Emit/MermaidPalette.cs
+++ b/src/SlnxMermaid.Core/Emit/MermaidPalette.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SlnxMermaid.Core.Config;
 
 namespace SlnxMermaid.Core.Emit
 {
@@ -18,26 +19,26 @@ namespace SlnxMermaid.Core.Emit
 
         public static MermaidPalette DarkModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
     {
-        { "blue", new MermaidNodeStyle("#1565C0", "#90CAF9", White) },
-        { "green", new MermaidNodeStyle("#2E7D32", "#A5D6A7", White) },
-        { "yellow", new MermaidNodeStyle("#F9A825", "#FFF59D", Black) },
-        { "orange", new MermaidNodeStyle("#EF6C00", "#FFCC80", White) },
-        { "pink", new MermaidNodeStyle("#AD1457", "#F48FB1", White) },
-        { "purple", new MermaidNodeStyle("#6A1B9A", "#CE93D8", White) },
-        { "gray", new MermaidNodeStyle("#37474F", "#B0BEC5", White) },
-        { "red", new MermaidNodeStyle("#B71C1C", "#EF9A9A", White) }
+        { UiPalette.Blue, new MermaidNodeStyle("#1565C0", "#90CAF9", White) },
+        { UiPalette.Green, new MermaidNodeStyle("#2E7D32", "#A5D6A7", White) },
+        { UiPalette.Yellow, new MermaidNodeStyle("#F9A825", "#FFF59D", Black) },
+        { UiPalette.Orange, new MermaidNodeStyle("#EF6C00", "#FFCC80", White) },
+        { UiPalette.Pink, new MermaidNodeStyle("#AD1457", "#F48FB1", White) },
+        { UiPalette.Purple, new MermaidNodeStyle("#6A1B9A", "#CE93D8", White) },
+        { UiPalette.Gray, new MermaidNodeStyle("#37474F", "#B0BEC5", White) },
+        { UiPalette.Red, new MermaidNodeStyle("#B71C1C", "#EF9A9A", White) }
     });
 
         public static MermaidPalette LightModePalette { get; private set; } = new MermaidPalette(new Dictionary<string, MermaidNodeStyle>(StringComparer.OrdinalIgnoreCase)
     {
-        { "blue", new MermaidNodeStyle("#E3F2FD", "#1976D2", Black) },
-        { "green", new MermaidNodeStyle("#E8F5E9", "#388E3C", Black) },
-        { "yellow", new MermaidNodeStyle("#FFFDE7", "#FBC02D", Black) },
-        { "orange", new MermaidNodeStyle("#FFF3E0", "#F57C00", Black) },
-        { "pink", new MermaidNodeStyle("#FCE4EC", "#C2185B", Black) },
-        { "purple", new MermaidNodeStyle("#F3E5F5", "#7B1FA2", Black) },
-        { "gray", new MermaidNodeStyle("#ECEFF1", "#607D8B", Black) },
-        { "red", new MermaidNodeStyle("#FFEBEE", "#D32F2F", Black) }
+        { UiPalette.Blue, new MermaidNodeStyle("#E3F2FD", "#1976D2", Black) },
+        { UiPalette.Green, new MermaidNodeStyle("#E8F5E9", "#388E3C", Black) },
+        { UiPalette.Yellow, new MermaidNodeStyle("#FFFDE7", "#FBC02D", Black) },
+        { UiPalette.Orange, new MermaidNodeStyle("#FFF3E0", "#F57C00", Black) },
+        { UiPalette.Pink, new MermaidNodeStyle("#FCE4EC", "#C2185B", Black) },
+        { UiPalette.Purple, new MermaidNodeStyle("#F3E5F5", "#7B1FA2", Black) },
+        { UiPalette.Gray, new MermaidNodeStyle("#ECEFF1", "#607D8B", Black) },
+        { UiPalette.Red, new MermaidNodeStyle("#FFEBEE", "#D32F2F", Black) }
     });
 
         public IEnumerable<string> Names

--- a/src/SlnxMermaid.Gui.Avalonia/Services/ConfigurationFormBuilder.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/Services/ConfigurationFormBuilder.cs
@@ -49,8 +49,9 @@ public sealed class ConfigurationFormBuilder : IConfigurationFormBuilder
             if (owner is SlnxMermaidConfig && string.Equals(name, nameof(SlnxMermaidConfig.Solution), StringComparison.Ordinal))
                 return new FilePathFieldViewModel(name, displayName, description, valueType, value?.ToString(), owner, property);
 
-            if (owner is DiagramConfig && string.Equals(name, nameof(DiagramConfig.Direction), StringComparison.Ordinal))
-                return new ChoiceFieldViewModel(name, displayName, description, valueType, new[] { "TD", "LR", "BT", "RL" }, value?.ToString(), owner, property);
+            var allowedValues = property.GetCustomAttribute<ConfigurationAllowedValuesAttribute>()?.Values;
+            if (allowedValues != null)
+                return new ChoiceFieldViewModel(name, displayName, description, valueType, allowedValues, value?.ToString(), owner, property);
 
             return new TextFieldViewModel(name, displayName, description, valueType, value?.ToString(), owner, property);
         }

--- a/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/DictionaryFieldViewModel.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/DictionaryFieldViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using SlnxMermaid.Core.Config;
 
 namespace SlnxMermaid.Gui.Avalonia.ViewModels.Form;
 
@@ -37,18 +38,7 @@ public sealed partial class DictionaryFieldViewModel : FormFieldViewModel
 
     public bool UsesColorEditor { get; }
 
-    public IReadOnlyList<string> ColorChoices { get; } = new[]
-    {
-        "blue",
-        "green",
-        "yellow",
-        "orange",
-        "pink",
-        "purple",
-        "gray",
-        "red",
-        "custom"
-    };
+    public IReadOnlyList<string> ColorChoices { get; } = UiPalette.Names.Concat(new[] { "custom" }).ToArray();
 
     [ObservableProperty]
     private string? newEntryKey;

--- a/tests/SlnxMermaid.Configuration.Tests/SchemaValidationTests.cs
+++ b/tests/SlnxMermaid.Configuration.Tests/SchemaValidationTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Json.Schema;
+using YamlDotNet.Serialization;
+
+namespace SlnxMermaid.Configuration.Tests;
+
+public sealed class SchemaValidationTests
+{
+    [Fact]
+    public void GeneratedSchema_ShouldMatchCommittedSchema()
+    {
+        var committedSchema = File.ReadAllText(GetRepositoryPath("schemas", "slnx-mermaid.schema.json"));
+
+        Assert.Equal(ConfigurationSchemaGenerator.Generate(), committedSchema);
+    }
+
+    [Fact]
+    public void SchemaFile_ShouldBeValidJsonSchema()
+    {
+        var schemaText = File.ReadAllText(GetRepositoryPath("schemas", "slnx-mermaid.schema.json"));
+
+        Assert.NotNull(JsonNode.Parse(schemaText));
+        Assert.NotNull(JsonSchema.FromText(schemaText));
+    }
+
+    [Fact]
+    public void ExampleConfig_ShouldConformToSchema()
+    {
+        var result = ValidateYaml(File.ReadAllText(GetRepositoryPath("examples", "slnx-mermaid.yml")));
+
+        Assert.True(result.IsValid, FormatErrors(result));
+    }
+
+    [Fact]
+    public void Validate_WhenDiagramDirectionIsInvalid_ShouldFail()
+    {
+        const string yaml = """
+            solution: Sample.slnx
+            diagram:
+              direction: diagonal
+            output:
+              file: dependency-graph.md
+            """;
+
+        var result = ValidateYaml(yaml);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_WhenUnknownRootPropertyExists_ShouldFail()
+    {
+        const string yaml = """
+            solution: Sample.slnx
+            unsupportedOption: true
+            output:
+              file: dependency-graph.md
+            """;
+
+        var result = ValidateYaml(yaml);
+
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_WhenUnknownNestedPropertyExists_ShouldFail()
+    {
+        const string yaml = """
+            solution: Sample.slnx
+            diagram:
+              direction: TD
+              unsupportedOption: true
+            output:
+              file: dependency-graph.md
+            """;
+
+        var result = ValidateYaml(yaml);
+
+        Assert.False(result.IsValid);
+    }
+
+    private static EvaluationResults ValidateYaml(string yaml)
+    {
+        var schemaText = File.ReadAllText(GetRepositoryPath("schemas", "slnx-mermaid.schema.json"));
+        var schema = JsonSchema.FromText(schemaText);
+        var yamlObject = new DeserializerBuilder().Build().Deserialize<object>(yaml);
+        var json = JsonSerializer.Serialize(ConvertYamlValue(yamlObject));
+        var node = JsonNode.Parse(json);
+
+        return schema.Evaluate(node, new EvaluationOptions { OutputFormat = OutputFormat.List });
+    }
+
+    private static object? ConvertYamlValue(object? value)
+    {
+        if (value is null)
+            return null;
+
+        if (value is IDictionary<object, object> objectDictionary)
+        {
+            return objectDictionary.ToDictionary(
+                pair => Convert.ToString(pair.Key, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                pair => ConvertYamlValue(pair.Value));
+        }
+
+        if (value is IDictionary<string, object> stringDictionary)
+            return stringDictionary.ToDictionary(pair => pair.Key, pair => ConvertYamlValue(pair.Value));
+
+        if (value is IEnumerable<object> sequence && value is not string)
+            return sequence.Select(ConvertYamlValue).ToArray();
+
+        return value;
+    }
+
+    private static string GetRepositoryPath(params string[] parts)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SlnxMermaid.slnx")))
+            directory = directory.Parent;
+
+        if (directory == null)
+            throw new DirectoryNotFoundException("Could not locate the repository root from the test output directory.");
+
+        return Path.Combine(new[] { directory.FullName }.Concat(parts).ToArray());
+    }
+
+    private static string FormatErrors(EvaluationResults results)
+    {
+        return $"Schema validation failed: {results}";
+    }
+}

--- a/tests/SlnxMermaid.Configuration.Tests/SchemaValidationTests.cs
+++ b/tests/SlnxMermaid.Configuration.Tests/SchemaValidationTests.cs
@@ -1,12 +1,16 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.Schema;
+using SlnxMermaid.Core.Config;
 using YamlDotNet.Serialization;
 
 namespace SlnxMermaid.Configuration.Tests;
 
 public sealed class SchemaValidationTests
 {
+    private static readonly Lazy<JsonSchema> ConfigurationSchema = new(() =>
+        JsonSchema.FromText(File.ReadAllText(GetRepositoryPath("schemas", "slnx-mermaid.schema.json"))));
+
     [Fact]
     public void GeneratedSchema_ShouldMatchCommittedSchema()
     {
@@ -21,7 +25,7 @@ public sealed class SchemaValidationTests
         var schemaText = File.ReadAllText(GetRepositoryPath("schemas", "slnx-mermaid.schema.json"));
 
         Assert.NotNull(JsonNode.Parse(schemaText));
-        Assert.NotNull(JsonSchema.FromText(schemaText));
+        Assert.NotNull(ConfigurationSchema.Value);
     }
 
     [Fact]
@@ -82,13 +86,15 @@ public sealed class SchemaValidationTests
 
     private static EvaluationResults ValidateYaml(string yaml)
     {
-        var schemaText = File.ReadAllText(GetRepositoryPath("schemas", "slnx-mermaid.schema.json"));
-        var schema = JsonSchema.FromText(schemaText);
-        var yamlObject = new DeserializerBuilder().Build().Deserialize<object>(yaml);
+        var schema = ConfigurationSchema.Value;
+        var yamlObject = new DeserializerBuilder()
+            .WithAttemptingUnquotedStringTypeDeserialization()
+            .Build()
+            .Deserialize<object>(yaml);
         var json = JsonSerializer.Serialize(ConvertYamlValue(yamlObject));
-        var node = JsonNode.Parse(json);
+        using var document = JsonDocument.Parse(json);
 
-        return schema.Evaluate(node, new EvaluationOptions { OutputFormat = OutputFormat.List });
+        return schema.Evaluate(document.RootElement, new EvaluationOptions { OutputFormat = OutputFormat.List });
     }
 
     private static object? ConvertYamlValue(object? value)
@@ -127,6 +133,6 @@ public sealed class SchemaValidationTests
 
     private static string FormatErrors(EvaluationResults results)
     {
-        return $"Schema validation failed: {results}";
+        return "Schema validation failed: " + JsonSerializer.Serialize(results, new JsonSerializerOptions { WriteIndented = true });
     }
 }

--- a/tests/SlnxMermaid.Configuration.Tests/SlnxMermaid.Configuration.Tests.csproj
+++ b/tests/SlnxMermaid.Configuration.Tests/SlnxMermaid.Configuration.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="JsonSchema.Net" Version="9.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/SlnxMermaid.Gui.Avalonia.Tests/ConfigurationFormBuilderTests.cs
+++ b/tests/SlnxMermaid.Gui.Avalonia.Tests/ConfigurationFormBuilderTests.cs
@@ -53,6 +53,15 @@ public sealed class ConfigurationFormBuilderTests
     }
 
     [Fact]
+    public void Build_WhenUiModeProperty_ShouldUseAllowedValuesFromConfigurationMetadata()
+    {
+        var fields = new ConfigurationFormBuilder().Build(new UiConfig());
+        var mode = Assert.IsType<ChoiceFieldViewModel>(fields.Single(field => field.Name == nameof(UiConfig.Mode)));
+
+        Assert.Equal(new[] { "dark", "light" }, mode.Values);
+    }
+
+    [Fact]
     public void Build_WhenPropertyIsBool_ShouldCreateBooleanFieldViewModel()
     {
         var fields = new ConfigurationFormBuilder().Build(new TestConfiguration());

--- a/tools/SlnxMermaid.SchemaGenerator/Program.cs
+++ b/tools/SlnxMermaid.SchemaGenerator/Program.cs
@@ -1,0 +1,20 @@
+using SlnxMermaid.Core.Config;
+
+var repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+var outputPath = args.Length > 0
+    ? Path.GetFullPath(args[0], Directory.GetCurrentDirectory())
+    : Path.Combine(repositoryRoot, "schemas", "slnx-mermaid.schema.json");
+
+Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+File.WriteAllText(outputPath, ConfigurationSchemaGenerator.Generate());
+Console.WriteLine($"Generated {Path.GetRelativePath(repositoryRoot, outputPath)}");
+
+static string FindRepositoryRoot(string startDirectory)
+{
+    var directory = new DirectoryInfo(startDirectory);
+    while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SlnxMermaid.slnx")))
+        directory = directory.Parent;
+
+    return directory?.FullName
+        ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
+}

--- a/tools/SlnxMermaid.SchemaGenerator/Program.cs
+++ b/tools/SlnxMermaid.SchemaGenerator/Program.cs
@@ -4,9 +4,16 @@ var repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
 var outputPath = args.Length > 0
     ? Path.GetFullPath(args[0], Directory.GetCurrentDirectory())
     : Path.Combine(repositoryRoot, "schemas", "slnx-mermaid.schema.json");
+var generatedSchema = ConfigurationSchemaGenerator.Generate();
+
+if (File.Exists(outputPath) && File.ReadAllText(outputPath) == generatedSchema)
+{
+    Console.WriteLine($"Schema is up to date: {Path.GetRelativePath(repositoryRoot, outputPath)}");
+    return;
+}
 
 Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-File.WriteAllText(outputPath, ConfigurationSchemaGenerator.Generate());
+File.WriteAllText(outputPath, generatedSchema);
 Console.WriteLine($"Generated {Path.GetRelativePath(repositoryRoot, outputPath)}");
 
 static string FindRepositoryRoot(string startDirectory)

--- a/tools/SlnxMermaid.SchemaGenerator/SlnxMermaid.SchemaGenerator.csproj
+++ b/tools/SlnxMermaid.SchemaGenerator/SlnxMermaid.SchemaGenerator.csproj
@@ -4,8 +4,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <SchemaOutputPath>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../../schemas/slnx-mermaid.schema.json'))</SchemaOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/SlnxMermaid.Configuration/SlnxMermaid.Configuration.csproj" />
   </ItemGroup>
+  <Target Name="GenerateSlnxMermaidConfigurationSchema"
+          AfterTargets="Build"
+          Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingSolutionFile)' == 'true'">
+    <Exec Command="dotnet &quot;$(TargetPath)&quot; &quot;$(SchemaOutputPath)&quot;" />
+  </Target>
 </Project>

--- a/tools/SlnxMermaid.SchemaGenerator/SlnxMermaid.SchemaGenerator.csproj
+++ b/tools/SlnxMermaid.SchemaGenerator/SlnxMermaid.SchemaGenerator.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/SlnxMermaid.Configuration/SlnxMermaid.Configuration.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### Motivation

- Provide a machine-readable JSON Schema for `slnx-mermaid.yml` so editors can offer IntelliSense and to prevent config-model drift. 
- Surface configuration metadata in the GUI and CLI and validate examples and committed schema automatically in CI.

### Description

- Add a schema generation tool at `tools/SlnxMermaid.SchemaGenerator` and a runtime generator `ConfigurationSchemaGenerator` that emits `schemas/slnx-mermaid.schema.json` from configuration classes and attributes. 
- Introduce configuration metadata attributes (`ConfigurationDescriptionAttribute`, `ConfigurationRequiredAttribute`, `ConfigurationAllowedValuesAttribute`, `ConfigurationStringConstraintAttribute`, `ConfigurationDictionaryValueAttribute`) and new config types (`UiPalette`, `UiStyleConfig`) and annotate existing config classes to drive schema output and UI behavior. 
- Wire editor integration with a checked-in VS Code settings file `.vscode/settings.json` and document YAML IntelliSense and schema regeneration in `README.md` and `docs/configuration.md`. 
- Add an example config `examples/slnx-mermaid.yml`, include the generator project in the solution, and update emitters/UI code to use the centralized `UiPalette` names. 
- Add automated tests `tests/SlnxMermaid.Configuration.Tests/SchemaValidationTests.cs` to ensure the generated schema matches the committed file and that example/variant YAML configs validate or fail as expected, and update GUI form builder tests to exercise new metadata-driven choices.

### Testing

- Ran the repository test suite with `dotnet test` which executed `SlnxMermaid.Configuration.Tests` and updated GUI tests and all tests completed successfully. 
- `SchemaValidationTests` verifies that `ConfigurationSchemaGenerator.Generate()` equals the committed `schemas/slnx-mermaid.schema.json` and that `examples/slnx-mermaid.yml` conforms to the schema, and these assertions passed. 
- Additional unit tests exercise the configuration form builder choices driven by `ConfigurationAllowedValuesAttribute`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235bb5429c8324b956bfdbca9f5806)