### PR TITLE
Reduce GitHub Actions storage usage

### DIFF
--- a/.github/workflows/CD-common-nuget.yml
+++ b/.github/workflows/CD-common-nuget.yml
@@ -15,7 +15,7 @@ permissions:
   packages: write
 
 jobs:
-  build:
+  build-test-and-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,42 +30,15 @@ jobs:
         run: dotnet build SlnxMermaid.slnx -c Release /p:Version=${{ inputs.version }}
 
       - name: Test
-        run: dotnet test SlnxMermaid.slnx -c Release /p:Version=${{ inputs.version }}
-
-  pack:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.0.x'
+        run: dotnet test SlnxMermaid.slnx -c Release --no-build /p:Version=${{ inputs.version }}
 
       - name: Pack CLI only
         run: |
           dotnet pack src/SlnxMermaid.CLI/SlnxMermaid.CLI.csproj \
             -c Release \
+            --no-build \
             /p:Version=${{ inputs.version }} \
             -o ./nupkg
-
-      - name: Upload NuGet package
-        uses: actions/upload-artifact@v4
-        with:
-          name: nuget-${{ inputs.channel }}-package
-          path: ./nupkg/*.nupkg
-
-  publish:
-    needs: pack
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download NuGet package
-        uses: actions/download-artifact@v8
-        with:
-          name: nuget-${{ inputs.channel }}-package
-          path: ./nupkg
 
       - name: Publish to NuGet
         env:

--- a/.github/workflows/CD-common-vsix.yml
+++ b/.github/workflows/CD-common-vsix.yml
@@ -11,12 +11,13 @@ on:
         type: string
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: windows-latest
 
     env:
       VS_MARKETPLACE_PUBLISHER_ID: SharpCode
       VS_MARKETPLACE_AUTHOR_DISPLAY_NAME: "Sharp Code"
+      VS_MARKETPLACE_INTERNAL_NAME: ${{ inputs.channel == 'rc' && 'slnxmermaid-rc' || 'slnxmermaid' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -103,30 +104,6 @@ jobs:
       - name: Build VSIX
         run: msbuild SlnxMermaidVisualStudio.slnx /t:Build /p:Configuration=Release /p:DeployExtension=false
 
-      - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: vsix-${{ inputs.channel }}-package
-          path: src/SlnxMermaidVsix/bin/**/*.vsix
-
-  publish:
-    needs: build
-    runs-on: windows-latest
-
-    env:
-      VS_MARKETPLACE_PUBLISHER_ID: SharpCode
-      VS_MARKETPLACE_INTERNAL_NAME: ${{ inputs.channel == 'rc' && 'slnxmermaid-rc' || 'slnxmermaid' }}
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: microsoft/setup-msbuild@v2
-
-      - name: Download VSIX artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: vsix-${{ inputs.channel }}-package
-          path: vsix
-
       - name: Locate VsixPublisher
         id: vsixpublisher
         shell: pwsh
@@ -191,8 +168,8 @@ jobs:
             throw "Missing VS_MARKETPLACE_TOKEN secret"
           }
 
-          $vsixPath = (Get-ChildItem vsix -Filter *.vsix -Recurse | Select-Object -First 1).FullName
-          if ([string]::IsNullOrWhiteSpace($vsixPath)) { throw "VSIX not found under ./vsix" }
+          $vsixPath = (Get-ChildItem src/SlnxMermaidVsix/bin -Filter *.vsix -Recurse | Select-Object -First 1).FullName
+          if ([string]::IsNullOrWhiteSpace($vsixPath)) { throw "VSIX not found under src/SlnxMermaidVsix/bin" }
 
           & "${{ steps.vsixpublisher.outputs.path }}" publish `
             -payload $vsixPath `

--- a/.github/workflows/CD-docs-pages.yml
+++ b/.github/workflows/CD-docs-pages.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
 
 permissions:
+  actions: write
   contents: read
   pages: write
   id-token: write
@@ -33,8 +34,18 @@ jobs:
           destination: ./_site
 
       - name: Upload artifact
+        id: upload
         uses: actions/upload-pages-artifact@v3
+        with:
+          retention-days: 1
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Delete deployed Pages artifact
+        if: always() && steps.upload.outputs.artifact_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact_id }}
+        run: gh api --method DELETE "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -109,6 +109,7 @@ jobs:
   CD-docs-pages:
     if: github.ref == 'refs/heads/master' && inputs.deploy_docs == true
     permissions:
+      actions: write
       contents: read
       pages: write
       id-token: write

--- a/.github/workflows/CI-build-linux-net10.yml
+++ b/.github/workflows/CI-build-linux-net10.yml
@@ -8,7 +8,7 @@ on:
         default: 10.0.x
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,14 +21,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
-
-      - name: Cache NuGet
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-
 
       - name: Restore
         run: dotnet restore SlnxMermaid.slnx
@@ -36,54 +28,8 @@ jobs:
       - name: Build
         run: dotnet build SlnxMermaid.slnx --no-restore
 
-      - name: Upload build outputs
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-outputs
-          path: |
-            **/bin/**
-            **/obj/**
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: ${{ inputs.dotnet_version }}
-
-      - name: Cache NuGet
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-
-
-      - name: Download build outputs
-        uses: actions/download-artifact@v8
-        with:
-          name: build-outputs
-          path: .
-
-      - name: Test (xUnit) with coverage (opencover)
+      - name: Test (xUnit)
         run: |
           dotnet test SlnxMermaid.slnx \
             --no-build \
-            --logger "trx;LogFileName=test-results.trx" \
-            /p:CollectCoverage=true \
-            /p:CoverletOutput=$(pwd)/coverage/coverage \
-            /p:CoverletOutputFormat=opencover
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: coverage
+            --logger "trx;LogFileName=test-results.trx"

--- a/.github/workflows/CI-dotnet-format.yml
+++ b/.github/workflows/CI-dotnet-format.yml
@@ -23,14 +23,6 @@ jobs:
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 
-      - name: Cache NuGet
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-
-
       - name: Restore
         run: dotnet restore SlnxMermaid.slnx
 

--- a/.github/workflows/CI-nuget-vulnerability-check.yml
+++ b/.github/workflows/CI-nuget-vulnerability-check.yml
@@ -30,14 +30,6 @@ jobs:
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 
-      - name: Cache NuGet
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-
-
       - name: Ensure tools
         run: |
           sudo apt-get update

--- a/.github/workflows/CI-sonar.yml
+++ b/.github/workflows/CI-sonar.yml
@@ -21,12 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Download coverage artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: coverage
-          path: coverage
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -48,6 +42,14 @@ jobs:
 
       - name: Build (Sonar)
         run: dotnet build SlnxMermaid.slnx
+
+      - name: Test with coverage (Sonar)
+        run: |
+          dotnet test SlnxMermaid.slnx \
+            --no-build \
+            /p:CollectCoverage=true \
+            /p:CoverletOutput=$(pwd)/coverage/coverage \
+            /p:CoverletOutputFormat=opencover
 
       - name: Sonar End
         env:

--- a/.github/workflows/maintenance-actions-storage.yml
+++ b/.github/workflows/maintenance-actions-storage.yml
@@ -1,0 +1,36 @@
+name: Maintenance - Actions storage
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 2 * * 0'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete stored artifacts and caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete all workflow artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[].id' \
+          | while read -r artifact_id; do
+              gh api --method DELETE "/repos/${{ github.repository }}/actions/artifacts/$artifact_id"
+            done
+
+      - name: Delete all Actions caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh cache list --repo "${{ github.repository }}" --limit 10000 --json id --jq '.[].id' \
+          | while read -r cache_id; do
+              gh cache delete "$cache_id" --repo "${{ github.repository }}"
+            done


### PR DESCRIPTION
### Motivation
- Ograniczyć zużycie GitHub Actions storage po przekroczeniu limitu przez usunięcie długotrwałych artefaktów i cache’ów. 
- Wyeliminować upload/download binarnych buildów, raportów coverage, paczek NuGet i VSIX między jobami, które zajmują najwięcej miejsca. 
- Zachować pełną weryfikację (build, testy, Sonar, publikacje) przy minimalnym wpływie na storage.

### Description
- Połączyłem build i testy w jednym jobie, dzięki czemu `**/bin/**` i `**/obj/**` nie są już przesyłane między runnerami jako artefakty. 
- Usunąłem `actions/cache` dla NuGet oraz większość `upload-artifact`/`download-artifact` używanych do przenoszenia `coverage`, `nupkg` i `vsix`; pakowanie i publikacja odbywają się na tym samym runnerze. 
- Przeniosłem generowanie raportu coverage bezpośrednio do jobu Sonar (`CI-sonar`) aby uniknąć uploadu/pobierania artefaktów coverage. 
- Dodałem ograniczenie retencji i natychmiastowe usuwanie dla artefaktu GitHub Pages (`retention-days: 1` + krok usuwający artefakt przez `gh api`) oraz nowy workflow `Maintenance - Actions storage` uruchamialny ręcznie lub zaplanowany, który usuwa istniejące artefakty i cache’y przez `gh cache`/`gh api`.

### Testing
- Parsowałem wszystkie pliki workflow `.github/workflows/*.yml` za pomocą Ruby Psych i każde YAML zostało poprawnie wczytane. 
- Uruchomione sprawdzenia: `git diff --check` oraz przeszukanie `rg` dla referencji do `actions/(upload-artifact|download-artifact|cache)` potwierdziły usunięcie większości storujących akcji poza wymaganym artefaktem Pages. 
- Zmiany zostały zacommitowane i utworzony PR z tymi workflowami, a `git status` potwierdził czysty stan roboczy po commicie. 
- Uwaga: `actionlint` nie został zainstalowany w tym środowisku z powodu blokady dostępu do `proxy.golang.org`, a lokalnie nie był dostępny `gh`, więc finalne usuwanie artefaktów trzeba uruchomić na runnerze GitHub (workflow `Maintenance - Actions storage`), który ma zainstalowany `gh`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29d846fc348324866f954deb9856cb)