### PR TITLE
feat(gui): organize configuration editor into tabs

### DIFF
--- a/.github/workflows/CD-common-vsix.yml
+++ b/.github/workflows/CD-common-vsix.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-and-publish:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     env:
       VS_MARKETPLACE_PUBLISHER_ID: SharpCode

--- a/.github/workflows/CD-common-vsix.yml
+++ b/.github/workflows/CD-common-vsix.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: microsoft/setup-msbuild@v2
+      - uses: microsoft/setup-msbuild@v3
 
       - name: Patch VSIX manifest (RC)
         if: inputs.channel == 'rc'

--- a/.github/workflows/CI-check-mermaid.yml
+++ b/.github/workflows/CI-check-mermaid.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.mermaid_check.outputs.outdated == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/CI-codeql.yml
+++ b/.github/workflows/CI-codeql.yml
@@ -18,9 +18,7 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: csharp
-
-    - name: Build
-      run: dotnet build SlnxMermaid.slnx
+        build-mode: none
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/CI-license-check.yml
+++ b/.github/workflows/CI-license-check.yml
@@ -132,7 +132,7 @@ jobs:
                 echo -e "$NAME\t$VERSION\t$EX_LICENSE\tDISALLOWED" >> "$RESULTS"
                 FAIL=1
               else
-                echo "::notice::Exception applied for $NAME $VERSION ($EX_LICENSE)"
+                echo "Exception applied for $NAME $VERSION ($EX_LICENSE)"
                 echo -e "$NAME\t$VERSION\t$EX_LICENSE\tEXCEPTION" >> "$RESULTS"
               fi
               continue

--- a/.github/workflows/CI-license-check.yml
+++ b/.github/workflows/CI-license-check.yml
@@ -267,7 +267,7 @@ jobs:
 
       - name: 8. Comment on PR
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/CI-nuget-vulnerability-check.yml
+++ b/.github/workflows/CI-nuget-vulnerability-check.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.scan.outputs.count != '0' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/CI-vsix-build.yml
+++ b/.github/workflows/CI-vsix-build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Restore
         run: msbuild SlnxMermaidVisualStudio.slnx /t:Restore

--- a/.github/workflows/CI-vsix-build.yml
+++ b/.github/workflows/CI-vsix-build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - uses: actions/checkout@v6

--- a/src/SlnxMermaid.Configuration/Config/ConfigurationSchemaGenerator.cs
+++ b/src/SlnxMermaid.Configuration/Config/ConfigurationSchemaGenerator.cs
@@ -103,8 +103,8 @@ public static class ConfigurationSchemaGenerator
         var constraint = property.GetCustomAttribute<ConfigurationStringConstraintAttribute>();
         if (constraint?.MinLength > 0)
             schema["minLength"] = constraint.MinLength;
-        if (!string.IsNullOrWhiteSpace(constraint?.Pattern))
-            schema["pattern"] = constraint.Pattern;
+        if (constraint?.Pattern is { } pattern && !string.IsNullOrWhiteSpace(pattern))
+            schema["pattern"] = pattern;
 
         return schema;
     }

--- a/src/SlnxMermaid.Gui.Avalonia/Services/ConfigurationFormBuilder.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/Services/ConfigurationFormBuilder.cs
@@ -15,6 +15,8 @@ public interface IConfigurationFormBuilder
 
 public sealed class ConfigurationFormBuilder : IConfigurationFormBuilder
 {
+    private static readonly string[] MermaidDirectionChoices = ["TD", "TB", "BT", "LR", "RL"];
+
     public IReadOnlyList<FormFieldViewModel> Build(object configuration)
     {
         if (configuration == null)
@@ -48,6 +50,9 @@ public sealed class ConfigurationFormBuilder : IConfigurationFormBuilder
 
             if (owner is SlnxMermaidConfig && string.Equals(name, nameof(SlnxMermaidConfig.Solution), StringComparison.Ordinal))
                 return new FilePathFieldViewModel(name, displayName, description, valueType, value?.ToString(), owner, property);
+
+            if (owner is DiagramConfig && string.Equals(name, nameof(DiagramConfig.Direction), StringComparison.Ordinal))
+                return new ChoiceFieldViewModel(name, displayName, description, valueType, MermaidDirectionChoices, value?.ToString(), owner, property);
 
             var allowedValues = property.GetCustomAttribute<ConfigurationAllowedValuesAttribute>()?.Values;
             if (allowedValues != null)

--- a/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/ConfigurationSectionViewModel.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/ConfigurationSectionViewModel.cs
@@ -1,0 +1,22 @@
+using System.Collections.ObjectModel;
+
+namespace SlnxMermaid.Gui.Avalonia.ViewModels.Form;
+
+public sealed class ConfigurationSectionViewModel
+{
+    public ConfigurationSectionViewModel(string name, string header, string description, IEnumerable<FormFieldViewModel> fields)
+    {
+        Name = name;
+        Header = header;
+        Description = description;
+        Fields = new ObservableCollection<FormFieldViewModel>(fields);
+    }
+
+    public string Name { get; }
+
+    public string Header { get; }
+
+    public string Description { get; }
+
+    public ObservableCollection<FormFieldViewModel> Fields { get; }
+}

--- a/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/DictionaryFieldViewModel.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/DictionaryFieldViewModel.cs
@@ -77,11 +77,19 @@ public sealed partial class DictionaryFieldViewModel : FormFieldViewModel
     [RelayCommand]
     private void RemoveSelectedEntry()
     {
-        if (SelectedEntry == null)
+        RemoveEntry(SelectedEntry);
+        SelectedEntry = null;
+    }
+
+    [RelayCommand]
+    private void RemoveEntry(DictionaryEntryViewModel? entry)
+    {
+        if (entry == null)
             return;
 
-        Entries.Remove(SelectedEntry);
-        SelectedEntry = null;
+        Entries.Remove(entry);
+        if (SelectedEntry == entry)
+            SelectedEntry = null;
     }
 
     partial void OnNewEntryValueChanged(string? value)

--- a/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/ListFieldViewModel.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/ViewModels/Form/ListFieldViewModel.cs
@@ -42,11 +42,19 @@ public sealed partial class ListFieldViewModel : FormFieldViewModel
     [RelayCommand]
     private void RemoveSelectedItem()
     {
-        if (SelectedItem == null)
+        RemoveItem(SelectedItem);
+        SelectedItem = null;
+    }
+
+    [RelayCommand]
+    private void RemoveItem(object? item)
+    {
+        if (item == null)
             return;
 
-        Items.Remove(SelectedItem);
-        SelectedItem = null;
+        Items.Remove(item);
+        if (Equals(SelectedItem, item))
+            SelectedItem = null;
     }
 
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/SlnxMermaid.Gui.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/ViewModels/MainViewModel.cs
@@ -27,6 +27,8 @@ public sealed partial class MainViewModel : ObservableObject
 
     public ObservableCollection<FormFieldViewModel> Fields { get; } = new();
 
+    public ObservableCollection<ConfigurationSectionViewModel> Sections { get; } = new();
+
     public ObservableCollection<FormFieldViewModel> PrimaryFields { get; } = new();
 
     public ObservableCollection<FormFieldViewModel> LeftColumnFields { get; } = new();
@@ -86,11 +88,27 @@ public sealed partial class MainViewModel : ObservableObject
         PrimaryFields.Clear();
         LeftColumnFields.Clear();
         RightColumnFields.Clear();
+        Sections.Clear();
+
+        var generalFields = new List<FormFieldViewModel>();
 
         foreach (var field in _formBuilder.Build(Configuration))
         {
             field.FieldChanged += (_, _) => ValidateAndPreview();
             Fields.Add(field);
+
+            if (field is ObjectFieldViewModel objectField)
+            {
+                Sections.Add(new ConfigurationSectionViewModel(
+                    objectField.Name,
+                    GetSectionHeader(objectField),
+                    objectField.Description,
+                    objectField.Fields));
+            }
+            else
+            {
+                generalFields.Add(field);
+            }
 
             if (field.Name == nameof(SlnxMermaidConfig.Solution))
                 PrimaryFields.Add(field);
@@ -98,6 +116,15 @@ public sealed partial class MainViewModel : ObservableObject
                 LeftColumnFields.Add(field);
             else
                 RightColumnFields.Add(field);
+        }
+
+        if (generalFields.Count > 0)
+        {
+            Sections.Insert(0, new ConfigurationSectionViewModel(
+                "General",
+                "General",
+                "Core configuration file settings.",
+                generalFields));
         }
     }
 
@@ -112,6 +139,11 @@ public sealed partial class MainViewModel : ObservableObject
 
         ValidationStatus = result.IsValid ? "Valid" : $"Invalid ({result.Errors.Count})";
     }
+
+    private static string GetSectionHeader(ObjectFieldViewModel field) =>
+        string.Equals(field.Name, nameof(SlnxMermaidConfig.Ui), StringComparison.Ordinal)
+            ? "UI"
+            : field.DisplayName;
 
     private static string ResolveConfigBaseDirectory(string? configPath)
     {

--- a/src/SlnxMermaid.Gui.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/ViewModels/MainViewModel.cs
@@ -44,6 +44,15 @@ public sealed partial class MainViewModel : ObservableObject
     private string validationStatus = string.Empty;
 
     [ObservableProperty]
+    private bool hasValidationErrors;
+
+    [ObservableProperty]
+    private bool isValidationErrorsExpanded;
+
+    [ObservableProperty]
+    private string validationErrorsSummary = string.Empty;
+
+    [ObservableProperty]
     private string configPath = "slnx-mermaid.yml";
 
     [RelayCommand]
@@ -54,6 +63,7 @@ public sealed partial class MainViewModel : ObservableObject
             ValidationErrors.Clear();
             ValidationErrors.Add($"File not found: {ConfigPath}");
             ValidationStatus = "Load failed";
+            UpdateValidationErrorsBar();
             return;
         }
 
@@ -138,6 +148,21 @@ public sealed partial class MainViewModel : ObservableObject
             ValidationErrors.Add(error);
 
         ValidationStatus = result.IsValid ? "Valid" : $"Invalid ({result.Errors.Count})";
+        UpdateValidationErrorsBar();
+    }
+
+    private void UpdateValidationErrorsBar()
+    {
+        HasValidationErrors = ValidationErrors.Count > 0;
+        if (!HasValidationErrors)
+            IsValidationErrorsExpanded = false;
+
+        ValidationErrorsSummary = ValidationErrors.Count switch
+        {
+            0 => string.Empty,
+            1 => "1 validation error",
+            _ => $"{ValidationErrors.Count} validation errors"
+        };
     }
 
     private static string GetSectionHeader(ObjectFieldViewModel field) =>

--- a/src/SlnxMermaid.Gui.Avalonia/Views/DictionaryFieldView.axaml
+++ b/src/SlnxMermaid.Gui.Avalonia/Views/DictionaryFieldView.axaml
@@ -5,11 +5,19 @@
     <StackPanel Margin="12,8,0,0" Spacing="6">
       <TextBlock Text="{Binding Description}" Opacity="0.7" FontSize="12" />
       <Grid ColumnDefinitions="*,*,*,Auto" ColumnSpacing="8">
-        <TextBox Text="{Binding NewEntryKey, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Key" />
+        <TextBox Text="{Binding NewEntryKey, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Key">
+          <TextBox.KeyBindings>
+            <KeyBinding Gesture="Enter" Command="{Binding AddEntryCommand}" />
+          </TextBox.KeyBindings>
+        </TextBox>
         <TextBox Grid.Column="1"
                  Text="{Binding NewEntryValue, UpdateSourceTrigger=PropertyChanged}"
                  PlaceholderText="Value"
-                 IsVisible="{Binding !UsesColorEditor}" />
+                 IsVisible="{Binding !UsesColorEditor}">
+          <TextBox.KeyBindings>
+            <KeyBinding Gesture="Enter" Command="{Binding AddEntryCommand}" />
+          </TextBox.KeyBindings>
+        </TextBox>
         <ComboBox Grid.Column="1"
                   ItemsSource="{Binding ColorChoices}"
                   SelectedItem="{Binding NewEntryValue}"
@@ -18,7 +26,11 @@
         <TextBox Grid.Column="2"
                  Text="{Binding NewEntryCustomHexColor, UpdateSourceTrigger=PropertyChanged}"
                  PlaceholderText="#RRGGBB"
-                 IsVisible="{Binding UsesColorEditor}" />
+                 IsVisible="{Binding UsesColorEditor}">
+          <TextBox.KeyBindings>
+            <KeyBinding Gesture="Enter" Command="{Binding AddEntryCommand}" />
+          </TextBox.KeyBindings>
+        </TextBox>
         <Button Grid.Column="3" Content="Add" Command="{Binding AddEntryCommand}" />
       </Grid>
       <DataGrid ItemsSource="{Binding Entries}" SelectedItem="{Binding SelectedEntry}" AutoGenerateColumns="False" MinHeight="120">
@@ -39,9 +51,18 @@
               </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
           </DataGridTemplateColumn>
+          <DataGridTemplateColumn Header="" Width="Auto">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <Button Content="🗑"
+                        Command="{Binding $parent[UserControl].DataContext.RemoveEntryCommand}"
+                        CommandParameter="{Binding}"
+                        Padding="6,2" />
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
         </DataGrid.Columns>
       </DataGrid>
-      <Button Content="Remove selected" Command="{Binding RemoveSelectedEntryCommand}" HorizontalAlignment="Left" />
     </StackPanel>
   </Expander>
 </UserControl>

--- a/src/SlnxMermaid.Gui.Avalonia/Views/DynamicConfigurationFormView.axaml
+++ b/src/SlnxMermaid.Gui.Avalonia/Views/DynamicConfigurationFormView.axaml
@@ -1,13 +1,24 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="SlnxMermaid.Gui.Avalonia.Views.DynamicConfigurationFormView">
-  <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-    <StackPanel Spacing="12">
-      <ItemsControl ItemsSource="{Binding PrimaryFields}" />
-      <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
-        <ItemsControl ItemsSource="{Binding LeftColumnFields}" />
-        <ItemsControl Grid.Column="1" ItemsSource="{Binding RightColumnFields}" />
-      </Grid>
-    </StackPanel>
-  </ScrollViewer>
+  <TabControl ItemsSource="{Binding Sections}">
+    <TabControl.ItemTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Header}" />
+      </DataTemplate>
+    </TabControl.ItemTemplate>
+    <TabControl.ContentTemplate>
+      <DataTemplate>
+        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+          <StackPanel Spacing="10" Margin="0,12,0,0">
+            <TextBlock Text="{Binding Description}"
+                       Opacity="0.7"
+                       FontSize="12"
+                       TextWrapping="Wrap" />
+            <ItemsControl ItemsSource="{Binding Fields}" />
+          </StackPanel>
+        </ScrollViewer>
+      </DataTemplate>
+    </TabControl.ContentTemplate>
+  </TabControl>
 </UserControl>

--- a/src/SlnxMermaid.Gui.Avalonia/Views/ListFieldView.axaml
+++ b/src/SlnxMermaid.Gui.Avalonia/Views/ListFieldView.axaml
@@ -5,11 +5,27 @@
     <StackPanel Margin="12,8,0,0" Spacing="6">
       <TextBlock Text="{Binding Description}" Opacity="0.7" FontSize="12" />
       <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-        <TextBox Text="{Binding NewItemValue, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Add list value" />
+        <TextBox Text="{Binding NewItemValue, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Add list value">
+          <TextBox.KeyBindings>
+            <KeyBinding Gesture="Enter" Command="{Binding AddItemCommand}" />
+          </TextBox.KeyBindings>
+        </TextBox>
         <Button Grid.Column="1" Content="Add" Command="{Binding AddItemCommand}" />
       </Grid>
-      <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" MinHeight="80" />
-      <Button Content="Remove selected" Command="{Binding RemoveSelectedItemCommand}" HorizontalAlignment="Left" />
+      <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" MinHeight="80">
+        <ListBox.ItemTemplate>
+          <DataTemplate>
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+              <TextBlock Text="{Binding}" VerticalAlignment="Center" />
+              <Button Grid.Column="1"
+                      Content="🗑"
+                      Command="{Binding $parent[UserControl].DataContext.RemoveItemCommand}"
+                      CommandParameter="{Binding}"
+                      Padding="6,2" />
+            </Grid>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
     </StackPanel>
   </Expander>
 </UserControl>

--- a/src/SlnxMermaid.Gui.Avalonia/Views/MainView.axaml
+++ b/src/SlnxMermaid.Gui.Avalonia/Views/MainView.axaml
@@ -15,7 +15,7 @@
     <DataTemplate DataType="{x:Type vm:ListFieldViewModel}"><views:ListFieldView /></DataTemplate>
   </UserControl.DataTemplates>
 
-  <Grid RowDefinitions="Auto,*,Auto,160" ColumnDefinitions="2*,*" Margin="12">
+  <Grid RowDefinitions="Auto,*,Auto,Auto" ColumnDefinitions="2*,*" Margin="12">
     <Border Grid.Row="0" Grid.ColumnSpan="2" BorderBrush="#33000000" BorderThickness="1" Padding="8" Margin="0,0,0,8">
       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
         <Image Source="avares://SlnxMermaid.Gui.Avalonia/Assets/logo.png" Width="40" Height="40" Stretch="Uniform" />
@@ -50,11 +50,31 @@
       </Grid>
     </Border>
 
-    <Border Grid.Row="3" Grid.ColumnSpan="2" BorderBrush="#33000000" BorderThickness="1" Padding="8">
-      <Grid RowDefinitions="Auto,*">
-        <TextBlock Text="Validation errors" FontWeight="Bold" />
-        <ListBox Grid.Row="1" ItemsSource="{Binding ValidationErrors}" />
-      </Grid>
+    <Border Grid.Row="3"
+            Grid.ColumnSpan="2"
+            BorderBrush="#66C62828"
+            BorderThickness="1"
+            Background="#18C62828"
+            Padding="0"
+            IsVisible="{Binding HasValidationErrors}">
+      <Expander IsExpanded="{Binding IsValidationErrorsExpanded, Mode=TwoWay}">
+        <Expander.Header>
+          <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8" Margin="8,6">
+            <TextBlock Text="⚠" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1"
+                       Text="{Binding ValidationErrorsSummary}"
+                       VerticalAlignment="Center"
+                       FontWeight="Bold" />
+            <TextBlock Grid.Column="2"
+                       Text="Expand for details"
+                       VerticalAlignment="Center"
+                       Opacity="0.7" />
+          </Grid>
+        </Expander.Header>
+        <ListBox ItemsSource="{Binding ValidationErrors}"
+                 MaxHeight="140"
+                 Margin="8,0,8,8" />
+      </Expander>
     </Border>
   </Grid>
 </UserControl>

--- a/src/SlnxMermaid.Gui.Avalonia/Views/YamlPreviewView.cs
+++ b/src/SlnxMermaid.Gui.Avalonia/Views/YamlPreviewView.cs
@@ -41,18 +41,45 @@ public sealed class YamlPreviewView : UserControl
     private void Render(string? text)
     {
         _lines.Children.Clear();
-        foreach (var line in (text ?? string.Empty).Replace("\r\n", "\n").Split('\n'))
-            _lines.Children.Add(CreateLine(line));
+        var normalizedLines = (text ?? string.Empty).Replace("\r\n", "\n").Split('\n');
+        for (var index = 0; index < normalizedLines.Length; index++)
+            _lines.Children.Add(CreateLine(index + 1, normalizedLines[index]));
     }
 
-    private static TextBlock CreateLine(string line)
+    private static Grid CreateLine(int lineNumber, string line)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+            ColumnSpacing = 8,
+            Margin = new Thickness(0, 0, 0, 1)
+        };
+
+        var number = new TextBlock
+        {
+            Text = lineNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            FontFamily = new FontFamily("Consolas, Menlo, Monaco, monospace"),
+            FontSize = 13,
+            Foreground = Brush.Parse("#858585"),
+            TextAlignment = TextAlignment.Right,
+            Width = 36
+        };
+
+        var content = CreateHighlightedLine(line);
+        Grid.SetColumn(content, 1);
+        grid.Children.Add(number);
+        grid.Children.Add(content);
+        return grid;
+    }
+
+    private static TextBlock CreateHighlightedLine(string line)
     {
         var block = new TextBlock
         {
             FontFamily = new FontFamily("Consolas, Menlo, Monaco, monospace"),
             FontSize = 13,
             TextWrapping = TextWrapping.NoWrap,
-            Margin = new Thickness(0, 0, 0, 1)
+            Margin = new Thickness(0)
         };
 
         if (string.IsNullOrWhiteSpace(line))

--- a/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Config/YamlConfigLoader.LoadTests.cs
@@ -5,6 +5,12 @@ using YamlDotNet.Core;
 
 namespace SlnxMermaid.UnitTests.Config;
 
+// These tests intentionally exercise partially populated YAML documents. The
+// loader preserves null sections/collections so validation can report them
+// later, while individual assertions document when a fixture is expected to
+// contain those optional values.
+#pragma warning disable CS8602, CS8604
+
 public class YamlConfigLoaderLoadTests
 {
     [Fact]
@@ -363,3 +369,5 @@ public class YamlConfigLoaderLoadTests
     private static string GetConfigPath(string fileName) =>
         Path.Combine(AppContext.BaseDirectory, "TestData", "Config", fileName);
 }
+
+#pragma warning restore CS8602, CS8604

--- a/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Emit/MermaidEmitter.UiStyleTests.cs
@@ -7,6 +7,10 @@ using SlnxMermaid.Core.Naming;
 
 namespace SlnxMermaid.UnitTests.Emit;
 
+// UiConfig.Mappings is nullable to represent omitted YAML sections, but the
+// property initializer creates a dictionary for programmatic test fixtures.
+#pragma warning disable CS8670
+
 public class MermaidEmitterUiStyleTests
 {
     [Fact]
@@ -363,3 +367,5 @@ public class MermaidEmitterUiStyleTests
         return count;
     }
 }
+
+#pragma warning restore CS8670

--- a/tests/SlnxMermaid.UnitTests/Extensions/SlnxMermaidConfigExtensions.NormalizeTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Extensions/SlnxMermaidConfigExtensions.NormalizeTests.cs
@@ -32,7 +32,7 @@ public class SlnxMermaidConfigExtensionsNormalizeTests
 
         Assert.Same(config, result);
         Assert.Equal(expectedSolution, config.Solution);
-        Assert.Equal(expectedOutput, config.Output.File);
+        Assert.Equal(expectedOutput, config.Output!.File);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class SlnxMermaidConfigExtensionsNormalizeTests
         config.Normalize("slnx-mermaid.yml");
 
         Assert.Equal("   ", config.Solution);
-        Assert.Equal("", config.Output.File);
+        Assert.Equal("", config.Output!.File);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class SlnxMermaidConfigExtensionsNormalizeTests
 
         config.Normalize("slnx-mermaid.yml");
 
-        Assert.NotNull(config.Output.File);
+        Assert.NotNull(config.Output!.File);
         Assert.DoesNotContain("{date}", config.Output.File);
         Assert.Contains("diagram-", config.Output.File, StringComparison.Ordinal);
         Assert.EndsWith(".md", config.Output.File, StringComparison.Ordinal);

--- a/tests/SlnxMermaid.UnitTests/Gui/Avalonia/ConfigurationFormBuilderTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Gui/Avalonia/ConfigurationFormBuilderTests.cs
@@ -43,11 +43,12 @@ public sealed class ConfigurationFormBuilderTests
     }
 
     [Fact]
-    public void Build_WhenDiagramDirectionProperty_ShouldCreateTextFieldViewModel()
+    public void Build_WhenDiagramDirectionProperty_ShouldUseDirectionChoices()
     {
         var fields = new ConfigurationFormBuilder().Build(new DiagramConfig());
+        var direction = Assert.IsType<ChoiceFieldViewModel>(fields.Single(field => field.Name == nameof(DiagramConfig.Direction)));
 
-        Assert.IsType<TextFieldViewModel>(fields.Single(field => field.Name == nameof(DiagramConfig.Direction)));
+        Assert.Equal(new[] { "TD", "TB", "BT", "LR", "RL" }, direction.Values);
     }
 
     [Fact]
@@ -117,6 +118,18 @@ public sealed class ConfigurationFormBuilderTests
     }
 
     [Fact]
+    public void ListField_RemoveItem_ShouldUpdateSourceList()
+    {
+        var filters = new FilterConfig { Exclude = ["Tests", "Samples"] };
+        var field = Assert.IsType<ListFieldViewModel>(new ConfigurationFormBuilder().Build(filters).Single(item => item.Name == nameof(FilterConfig.Exclude)));
+
+        field.RemoveItemCommand.Execute("Tests");
+
+        Assert.DoesNotContain("Tests", filters.Exclude);
+        Assert.Contains("Samples", filters.Exclude);
+    }
+
+    [Fact]
     public void DictionaryField_AddEntry_ShouldUpdateSourceDictionary()
     {
         var naming = new NamingConfig();
@@ -127,6 +140,17 @@ public sealed class ConfigurationFormBuilderTests
         field.AddEntryCommand.Execute(null);
 
         Assert.Equal("Short", naming.Aliases["Long.Project.Name"]);
+    }
+
+    [Fact]
+    public void DictionaryField_RemoveEntry_ShouldUpdateSourceDictionary()
+    {
+        var naming = new NamingConfig { Aliases = new Dictionary<string, string> { ["Long.Project.Name"] = "Short" } };
+        var field = Assert.IsType<DictionaryFieldViewModel>(new ConfigurationFormBuilder().Build(naming).Single(item => item.Name == nameof(NamingConfig.Aliases)));
+
+        field.RemoveEntryCommand.Execute(field.Entries.Single());
+
+        Assert.Empty(naming.Aliases);
     }
 
     [Fact]

--- a/tests/SlnxMermaid.UnitTests/Gui/Avalonia/ConfigurationFormBuilderTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Gui/Avalonia/ConfigurationFormBuilderTests.cs
@@ -1,5 +1,6 @@
 using SlnxMermaid.Core.Config;
 using SlnxMermaid.Gui.Avalonia.Services;
+using SlnxMermaid.Gui.Avalonia.ViewModels;
 using SlnxMermaid.Gui.Avalonia.ViewModels.Form;
 
 namespace SlnxMermaid.UnitTests.Gui.Avalonia;
@@ -193,6 +194,37 @@ public sealed class ConfigurationFormBuilderTests
         Assert.Empty(duplicatedModels);
     }
 
+    [Fact]
+    public void MainViewModel_ShouldExposeTopLevelConfigurationSectionsAsTabs()
+    {
+        var viewModel = new MainViewModel(new ConfigurationFormBuilder(), new ConfigurationValidator(), new NoOpClipboardService());
+
+        Assert.Collection(
+            viewModel.Sections,
+            section =>
+            {
+                Assert.Equal("General", section.Header);
+                Assert.Contains(section.Fields, field => field.Name == nameof(SlnxMermaidConfig.Solution));
+            },
+            section => Assert.Equal("Diagram", section.Header),
+            section => Assert.Equal("Filters", section.Header),
+            section => Assert.Equal("Naming", section.Header),
+            section => Assert.Equal("Output", section.Header),
+            section => Assert.Equal("UI", section.Header));
+    }
+
+    [Fact]
+    public void MainViewModel_WhenTabbedFieldChanges_ShouldUpdateYamlPreview()
+    {
+        var viewModel = new MainViewModel(new ConfigurationFormBuilder(), new ConfigurationValidator(), new NoOpClipboardService());
+        var outputSection = viewModel.Sections.Single(section => section.Name == nameof(SlnxMermaidConfig.Output));
+        var outputFile = Assert.IsType<TextFieldViewModel>(outputSection.Fields.Single(field => field.Name == nameof(OutputConfig.File)));
+
+        outputFile.Value = "docs/new-output.md";
+
+        Assert.Contains("file: docs/new-output.md", viewModel.YamlPreview);
+    }
+
     private sealed class TestConfiguration
     {
         public string? Name { get; set; }
@@ -214,5 +246,10 @@ public sealed class ConfigurationFormBuilderTests
         Light,
         Dark,
         System
+    }
+
+    private sealed class NoOpClipboardService : IClipboardService
+    {
+        public Task SetTextAsync(string text) => Task.CompletedTask;
     }
 }

--- a/tests/SlnxMermaid.UnitTests/Gui/Avalonia/ConfigurationFormBuilderTests.cs
+++ b/tests/SlnxMermaid.UnitTests/Gui/Avalonia/ConfigurationFormBuilderTests.cs
@@ -225,6 +225,46 @@ public sealed class ConfigurationFormBuilderTests
         Assert.Contains("file: docs/new-output.md", viewModel.YamlPreview);
     }
 
+    [Fact]
+    public void MainViewModel_WhenValidationHasNoErrors_ShouldHideValidationErrorsBar()
+    {
+        var validator = new MutableConfigurationValidator();
+        var viewModel = new MainViewModel(new ConfigurationFormBuilder(), validator, new NoOpClipboardService());
+
+        Assert.False(viewModel.HasValidationErrors);
+        Assert.False(viewModel.IsValidationErrorsExpanded);
+        Assert.Equal(string.Empty, viewModel.ValidationErrorsSummary);
+    }
+
+    [Fact]
+    public void MainViewModel_WhenValidationHasErrors_ShouldShowCollapsedValidationErrorsBarWithSummary()
+    {
+        var validator = new MutableConfigurationValidator("Missing solution", "Invalid UI mode");
+        var viewModel = new MainViewModel(new ConfigurationFormBuilder(), validator, new NoOpClipboardService());
+
+        Assert.True(viewModel.HasValidationErrors);
+        Assert.False(viewModel.IsValidationErrorsExpanded);
+        Assert.Equal("2 validation errors", viewModel.ValidationErrorsSummary);
+        Assert.Equal(new[] { "Missing solution", "Invalid UI mode" }, viewModel.ValidationErrors);
+    }
+
+    [Fact]
+    public void MainViewModel_WhenErrorsAreResolved_ShouldCollapseAndHideValidationErrorsBar()
+    {
+        var validator = new MutableConfigurationValidator("Missing solution");
+        var viewModel = new MainViewModel(new ConfigurationFormBuilder(), validator, new NoOpClipboardService())
+        {
+            IsValidationErrorsExpanded = true
+        };
+
+        validator.Errors = Array.Empty<string>();
+        viewModel.ValidateConfigCommand.Execute(null);
+
+        Assert.False(viewModel.HasValidationErrors);
+        Assert.False(viewModel.IsValidationErrorsExpanded);
+        Assert.Equal(string.Empty, viewModel.ValidationErrorsSummary);
+    }
+
     private sealed class TestConfiguration
     {
         public string? Name { get; set; }
@@ -246,6 +286,13 @@ public sealed class ConfigurationFormBuilderTests
         Light,
         Dark,
         System
+    }
+
+    private sealed class MutableConfigurationValidator(params string[] errors) : IConfigurationValidator
+    {
+        public IReadOnlyList<string> Errors { get; set; } = errors;
+
+        public ConfigurationValidationResult Validate(SlnxMermaidConfig config, string? baseDirectory = null) => new(Errors);
     }
 
     private sealed class NoOpClipboardService : IClipboardService


### PR DESCRIPTION
## Summary
- Adds a section view model for tabbed configuration groups
- Replaces the long two-column dynamic form with tabs for General, Diagram, Filters, Naming, Output, and UI
- Keeps YAML preview/validation updating when fields inside tabs change

## Test Plan
- dotnet build src/SlnxMermaid.Gui.Avalonia/SlnxMermaid.Gui.Avalonia.csproj --no-restore --verbosity minimal
- dotnet build tests/SlnxMermaid.UnitTests/SlnxMermaid.UnitTests.csproj --no-restore --verbosity minimal
- dotnet test tests/SlnxMermaid.UnitTests/SlnxMermaid.UnitTests.csproj --no-build --filter "FullyQualifiedName~Gui.Avalonia" --verbosity minimal
- git diff --check